### PR TITLE
feat: add support for prometheus operator config

### DIFF
--- a/istio-telemetry/prometheus-operator/Chart.yaml
+++ b/istio-telemetry/prometheus-operator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: prometheus-operator
+version: 1.1.0
+appVersion: 2.3.1
+tillerVersion: ">=2.7.2"

--- a/istio-telemetry/prometheus-operator/templates/_affinity.tpl
+++ b/istio-telemetry/prometheus-operator/templates/_affinity.tpl
@@ -1,0 +1,86 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.global.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.global.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "podAntiAffinity" }}
+{{- if or .Values.podAntiAffinityLabelSelector .Values.podAntiAffinityTermLabelSelector}}
+  podAntiAffinity:
+    {{- if .Values.podAntiAffinityLabelSelector }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "podAntiAffinityRequiredDuringScheduling" . }}
+    {{- end }}
+    {{- if or .Values.podAntiAffinityTermLabelSelector}}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "podAntiAffinityPreferredDuringScheduling" . }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "podAntiAffinityRequiredDuringScheduling" }}
+    {{- range $index, $item := .Values.podAntiAffinityLabelSelector }}
+    - labelSelector:
+        matchExpressions:
+        - key: {{ $item.key }}
+          operator: {{ $item.operator }}
+          {{- if $item.value }}
+          values:
+          {{- $vals := split "," $item.values }}
+          {{- range $i, $v := $vals }}
+          - {{ $v }}
+          {{- end }}
+          {{- end }}
+      topologyKey: {{ $item.topologyKey }}
+    {{- end }}
+{{- end }}
+
+{{- define "podAntiAffinityPreferredDuringScheduling" }}
+    {{- range $index, $item := .Values.podAntiAffinityTermLabelSelector }}
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: {{ $item.key }}
+            operator: {{ $item.operator }}
+            {{- if $item.values }}
+            values:
+            {{- $vals := split "," $item.values }}
+            {{- range $i, $v := $vals }}
+            - {{ $v }}
+            {{- end }}
+            {{- end }}
+        topologyKey: {{ $item.topologyKey }}
+      weight: 100
+    {{- end }}
+{{- end }}

--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -4,6 +4,8 @@ kind: Prometheus
 metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
 spec:
   image: "{{ .Values.prometheus.hub }}/prometheus:{{ .Values.prometheus.tag }}"
   version: {{ .Values.prometheus.tag }}

--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.createPrometheusResource }}
+{{- if .Values.prometheus.createPrometheusResource }}
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
 spec:
-  image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
-  version: {{ .Values.tag }}
-  retention: {{ .Values.retention }}
-  scrapeInterval: {{ .Values.scrapeInterval }}
+  image: "{{ .Values.prometheus.hub }}/prometheus:{{ .Values.prometheus.tag }}"
+  version: {{ .Values.prometheus.tag }}
+  retention: {{ .Values.prometheus.retention }}
+  scrapeInterval: {{ .Values.prometheus.scrapeInterval }}
   serviceAccountName: prometheus
   serviceMonitorSelector:
     any: true
@@ -93,7 +93,7 @@ spec:
     tls:
       mode: DISABLE
 ---
-{{- if not .Values.service.nodePort.enabled }}
+{{- if not .Values.prometheus.service.nodePort.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -102,7 +102,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
     {{- if .Values.service }}
-    {{- range $key, $val := .Values.service.annotations }}
+    {{- range $key, $val := .Values.prometheus.service.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
     {{- end }}
@@ -130,7 +130,7 @@ spec:
   type: NodePort
   ports:
   - port: 9090
-    nodePort: {{ .Values.service.nodePort.port }}
+    nodePort: {{ .Values.prometheus.service.nodePort.port }}
     name: http-prometheus
   selector:
     app: prometheus

--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -1,0 +1,153 @@
+{{- if .Values.createPrometheusResource }}
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
+  version: {{ .Values.tag }}
+  retention: {{ .Values.retention }}
+  scrapeInterval: {{ .Values.scrapeInterval }}
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    any: true
+  serviceMonitorNamespaceSelector:
+    any: true
+  secrets: [ istio.prometheus ]
+  enableAdminAPI: false
+{{- if .Values.global.priorityClassName }}
+  priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
+  affinity:
+  {{- include "nodeaffinity" . | indent 2 }}
+  {{- include "podAntiAffinity" . | indent 2 }}
+  podMetadata:
+    labels:
+      app: prometheus
+      release: {{ .Release.Name }}
+    annotations:
+      sidecar.istio.io/inject: "false"
+  resources:
+    requests:
+      memory: 400Mi
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus-{{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  - nodes/proxy
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-{{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  host: prometheus.{{ .Release.Namespace }}
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: prometheus-full
+  namespace: {{ .Release.Namespace }}
+spec:
+  host: prometheus.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+{{- if not .Values.service.nodePort.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    {{- if .Values.service }}
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
+  labels:
+    app: prometheus
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - name: http-prometheus
+    protocol: TCP
+    port: 9090
+{{- else }}
+# Using separate ingress for nodeport, to avoid conflict with pilot e2e test configs.
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-nodeport
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    release: {{ .Release.Name }}
+spec:
+  type: NodePort
+  ports:
+  - port: 9090
+    nodePort: {{ .Values.service.nodePort.port }}
+    name: http-prometheus
+  selector:
+    app: prometheus
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    release: {{ .Release.Name }}
+{{- end }}

--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -14,7 +14,7 @@ spec:
       - {{ .Values.global.telemetryNamespace }}
   endpoints:
   - port: prometheus
-    interval: {{ .Values.scrapeInterval }}
+    interval: {{ .Values.prometheus.scrapeInterval }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -31,7 +31,7 @@ spec:
     any: true
   endpoints:
   - port: http-monitoring 
-    interval: {{ .Values.scrapeInterval }}
+    interval: {{ .Values.prometheus.scrapeInterval }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -50,7 +50,7 @@ spec:
   endpoints:
   - path: /stats/prometheus
     targetPort: 15090
-    interval: {{ .Values.scrapeInterval }}
+    interval: {{ .Values.prometheus.scrapeInterval }}
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_container_port_name]
       action: keep
@@ -79,7 +79,7 @@ spec:
     any: true
   jobLabel: kubernetes-pods
   endpoints:
-  - interval: {{ .Values.scrapeInterval }}
+  - interval: {{ .Values.prometheus.scrapeInterval }}
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
@@ -123,7 +123,7 @@ spec:
     any: true
   jobLabel: kubernetes-pods-secure
   endpoints:
-  - interval: {{ .Values.scrapeInterval }}
+  - interval: {{ .Values.prometheus.scrapeInterval }}
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/secrets/istio.prometheus/root-cert.pem
@@ -178,7 +178,7 @@ spec:
     any: true
   jobLabel: kubernetes-services
   endpoints:
-  - interval: {{ .Values.scrapeInterval }}
+  - interval: {{ .Values.prometheus.scrapeInterval }}
     relabelings:
     - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
       action: keep
@@ -222,7 +222,7 @@ spec:
     any: true
   jobLabel: kubernetes-services-secure
   endpoints:
-  - interval: {{ .Values.scrapeInterval }}
+  - interval: {{ .Values.prometheus.scrapeInterval }}
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/secrets/istio.prometheus/root-cert.pem

--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -1,0 +1,263 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istio-mesh-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: istio-mesh
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio, operator: In, values: [mixer]}
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.global.telemetryNamespace }}
+  endpoints:
+  - port: prometheus
+    interval: {{ .Values.scrapeInterval }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istio-component-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: istio-components
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio, operator: In, values: [mixer,pilot,galley,citadel]}
+  namespaceSelector:
+    any: true
+  endpoints:
+  - port: http-monitoring 
+    interval: {{ .Values.scrapeInterval }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-stats-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: istio-proxies
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: envoy-stats
+  endpoints:
+  - path: /stats/prometheus
+    targetPort: 15090
+    interval: {{ .Values.scrapeInterval }}
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_container_port_name]
+      action: keep
+      regex: '.*-envoy-prom'
+    - action: labelmap
+      regex: "__meta_kubernetes_pod_label_(.+)"
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-pods-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: kube-pods
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-pods
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_prometheus_io_scheme]
+      action: keep
+      regex: '((;.*)|(.*;http)|(.??))'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_istio_mtls]
+      action: drop
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-pods-secure-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: kube-pods-secure
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-pods-secure
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.prometheus/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.prometheus/cert-chain.pem
+      keyFile: /etc/prometheus/secrets/istio.prometheus/key.pem
+      insecureSkipVerify: true  # prometheus does not support secure naming.
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    # sidecar status annotation is added by sidecar injector and
+    # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
+      action: keep
+      regex: '(([^;]+);([^;]*))|(([^;]*);(true))'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+      action: drop
+      regex: '(http)'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__]  # Only keep address that is host:port
+      action: keep    # otherwise an extra target with ':443' is added for https scheme
+      regex: '([^:]+):(\d+)'
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-services-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: kube-services
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-services
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: keep
+      regex: '((;.*)|(.*;http)|(.??))'
+    - sourceLabels: [__meta_kubernetes_pod_annotation_istio_mtls]
+      action: drop
+      regex: 'true'
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubernetes-services-secure-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    monitoring: kube-services-secure
+spec:
+  selector:
+    matchExpressions:
+      - {key: istio-prometheus-ignore, operator: DoesNotExist}
+  namespaceSelector:
+    any: true
+  jobLabel: kubernetes-services-secure
+  endpoints:
+  - interval: {{ .Values.scrapeInterval }}
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.prometheus/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.prometheus/cert-chain.pem
+      keyFile: /etc/prometheus/secrets/istio.prometheus/key.pem
+      insecureSkipVerify: true  # prometheus does not support secure naming.
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: 'true'
+    # sidecar status annotation is added by sidecar injector and
+    # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+    - sourceLabels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
+      action: keep
+      regex: '(([^;]+);([^;]*))|(([^;]*);(true))'
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: drop
+      regex: '(http)'
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: '(.+)'
+    - sourceLabels: [__address__]  # Only keep address that is host:port
+      action: keep    # otherwise an extra target with ':443' is added for https scheme
+      regex: '([^:]+):(\d+)'
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      regex: '([^:]+)(?::\d+)?;(\d+)'
+      replacement: $1:$2
+      targetLabel: __address__
+    - action: labelmap
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name

--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-mesh
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:
@@ -23,6 +24,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-components
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:
@@ -40,6 +42,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: istio-proxies
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:
@@ -71,6 +74,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-pods
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:
@@ -115,6 +119,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-pods-secure
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:
@@ -170,6 +175,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-services
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:
@@ -214,6 +220,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     monitoring: kube-services-secure
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchExpressions:

--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -32,7 +32,9 @@ spec:
   namespaceSelector:
     any: true
   endpoints:
-  - port: http-monitoring 
+  - port: http-monitoring
+    interval: {{ .Values.prometheus.scrapeInterval }}
+  - port: http-policy-monitoring
     interval: {{ .Values.prometheus.scrapeInterval }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/istio-telemetry/prometheus-operator/values.yaml
+++ b/istio-telemetry/prometheus-operator/values.yaml
@@ -1,18 +1,19 @@
-# Controls the default scrape interval used in the ServiceMonitors
-scrapeInterval: 15s
+prometheus:
+  # Controls the default scrape interval used in the ServiceMonitors
+  scrapeInterval: 15s
 
-# Enabling this option will generate a Prometheus resource, causing the operator
-# to create a prometheus deployment according to the generated spec. It will also
-# create a service definition, destination rules, cluster roles and bindings, and
-# a service account. Only use this option if you have not already created and configured
-# a prometheus resource and/or you desire a distinct prometheus resource for Istio.
-createPrometheusResource: false
-hub: docker.io/prom
-tag: v2.8.0
-retention: 6h
+  # Enabling this option will generate a Prometheus resource, causing the operator
+  # to create a prometheus deployment according to the generated spec. It will also
+  # create a service definition, destination rules, cluster roles and bindings, and
+  # a service account. Only use this option if you have not already created and configured
+  # a prometheus resource and/or you desire a distinct prometheus resource for Istio.
+  createPrometheusResource: false
+  hub: docker.io/prom
+  tag: v2.8.0
+  retention: 6h
 
-service:
-  annotations: {}
-  nodePort:
-    enabled: false
-    port: 32090
+  service:
+    annotations: {}
+    nodePort:
+      enabled: false
+      port: 32090

--- a/istio-telemetry/prometheus-operator/values.yaml
+++ b/istio-telemetry/prometheus-operator/values.yaml
@@ -1,0 +1,18 @@
+# Controls the default scrape interval used in the ServiceMonitors
+scrapeInterval: 15s
+
+# Enabling this option will generate a Prometheus resource, causing the operator
+# to create a prometheus deployment according to the generated spec. It will also
+# create a service definition, destination rules, cluster roles and bindings, and
+# a service account. Only use this option if you have not already created and configured
+# a prometheus resource and/or you desire a distinct prometheus resource for Istio.
+createPrometheusResource: false
+hub: docker.io/prom
+tag: v2.8.0
+retention: 6h
+
+service:
+  annotations: {}
+  nodePort:
+    enabled: false
+    port: 32090

--- a/test/install.mk
+++ b/test/install.mk
@@ -135,6 +135,6 @@ install-prometheus-operator:
 # This target expects that the prometheus operator (and its CRDs have already been installed).
 # It is provided as a way to install Istio prometheus operator config in isolation.
 install-prometheus-operator-config:
-	kubectl create ns ${ISTIO_NS} || /bin/true
+	kubectl create ns ${ISTIO_NS} || true
 	# NOTE: we don't use iop to install, as it defaults to `--prune`, which is incompatible with the prom operator (it prunes the stateful set)
 	bin/iop ${ISTIO_NS} istio-prometheus-operator ${BASE}/istio-telemetry/prometheus-operator/ -t ${PROM_OPTS} | kubectl apply -n ${ISTIO_NS} -f -

--- a/test/install.mk
+++ b/test/install.mk
@@ -126,3 +126,15 @@ install-policy:
 	bin/iop ${ISTIO_NS} istio-policy ${BASE}/istio-policy  ${IOP_OPTS}
 	kubectl wait deployments istio-policy -n ${ISTIO_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 
+# This target should only be used in situations in which the prom operator has not already been installed in a cluster.
+install-prometheus-operator:
+	# installs the prom operator in the default namespace
+	kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
+	kubectl wait --for=condition=available --timeout=${WAIT_TIMEOUT} deploy/prometheus-operator
+
+# This target expects that the prometheus operator (and its CRDs have already been installed).
+# It is provided as a way to install Istio prometheus operator config in isolation.
+install-prometheus-operator-config:
+	kubectl create ns ${ISTIO_NS} || /bin/true
+	# NOTE: we don't use iop to install, as it defaults to `--prune`, which is incompatible with the prom operator (it prunes the stateful set)
+	bin/iop ${ISTIO_NS} istio-prometheus-operator ${BASE}/istio-telemetry/prometheus-operator/ -t ${PROM_OPTS} | kubectl apply -n ${ISTIO_NS} -f -


### PR DESCRIPTION
This PR is an attempt to add support for generating Prometheus Operator config to Istio. It is a port of https://github.com/istio/istio/pull/13407.

This PR assumes that the Prometheus Operator itself has been previously installed (example: `kubectl -n prom-operator apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml`).

Motivations (Code Mauve):
- https://github.com/istio/istio/issues/10134
- https://github.com/istio/istio/issues/7528
- https://github.com/istio/istio/issues/5673
- https://github.com/istio/istio/issues/12915
- https://discuss.istio.io/t/istio-prometheus-to-scrape-metrics-from-service-specific-metrics-endpoint/926
- https://discuss.istio.io/t/how-to-update-prometheus-config/935
- https://discuss.istio.io/t/istio-1-1-daily-byo-prometheus-via-operator/418
- https://discuss.istio.io/t/is-envoy-metrics-not-pushed-via-statsd-after-1-1/1883

NOTE: I have not tested this fully yet. I have only copied it over from the other PR.