### PR TITLE
Fix INGRESS HOST and PORT for local cluster

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -96,11 +96,13 @@ n=1
 while true
 do
     export INGRESS_HOST=$(kubectl -n ${INGRESS_NS} get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    if [ -z $INGRESS_HOST ]; then
-        export INGRESS_HOST=$(kubectl -n ${INGRESS_NS} get service istio-ingressgateway -o jsonpath='{.spec.clusterIP}')
-    fi
     export INGRESS_PORT=$(kubectl -n ${INGRESS_NS} get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
     export SECURE_INGRESS_PORT=$(kubectl -n ${INGRESS_NS} get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
+    if [ -z $INGRESS_HOST ]; then
+        export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n ${INGRESS_NS} -o jsonpath='{.items[0].status.hostIP}')
+        export INGRESS_PORT=$(kubectl -n ${INGRESS_NS} get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+        export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+    fi
     export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
     RESULT=$(curl -s -o /dev/null -w "%{http_code}" http://${GATEWAY_URL}/productpage)
     if [ $RESULT -eq "200"  ]; then


### PR DESCRIPTION
To fix the Make run-bookinfo target failure, update the INGRESS_HOST and INGRESS_PORT to use node port values when external load balancer is not avaialble.