### PR TITLE
Fix minikube install to use Make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - run: 
           command: |
             export PATH=/go/bin:$PATH
-            WAIT_TIMEOUT=10m bin/install.sh
+            WAIT_TIMEOUT=10m make demo-install
       - run:
           command: make info dep
       - run:

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,9 @@ ifeq ($(SKIP_CLEANUP), 0)
 	$(MAKE) clean
 endif
 
+demo-install:
+	bin/install.sh
+
 .PHONY: ${GOPATH}/out/yaml/crds
 # Install CRDS
 install-crds: crds


### PR DESCRIPTION
Minikube install doesn't get right environment variables because it is
calling the script directly, causing failures.

Signed-off-by: John Howard <howardjohn@google.com>