### PR TITLE
update tracing namespace.

### DIFF
--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -88,8 +88,8 @@ spec:
           - --zipkinAddress
         {{- if .Values.global.tracer.zipkin.address }}
           - {{ .Values.global.tracer.zipkin.address }}
-        {{- else if .Values.global.istioNamespace }}
-          - zipkin.{{ .Values.global.istioNamespace }}:9411
+        {{- else if .Values.global.telemetryNamespace }}
+          - zipkin.{{ .Values.global.telemetryNamespace }}:9411
         {{- else }}
           - zipkin:9411
         {{- end }}

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -108,8 +108,8 @@ spec:
           - --zipkinAddress
         {{- if .Values.global.tracer.zipkin.address }}
           - {{ .Values.global.tracer.zipkin.address }}
-        {{- else if .Values.global.istioNamespace }}
-          - zipkin.{{ .Values.global.istioNamespace }}:9411
+        {{- else if .Values.global.telemetryNamespace }}
+          - zipkin.{{ .Values.global.telemetryNamespace }}:9411
         {{- else }}
           - zipkin:9411
         {{- end }}

--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -134,7 +134,7 @@ data:
         {{- if .Values.global.tracer.zipkin.address }}
           address: {{ .Values.global.tracer.zipkin.address }}
         {{- else }}
-          address: zipkin.{{ .Release.Namespace }}:9411
+          address: zipkin.{{ .Values.global.telemetryNamespace }}:9411
         {{- end }}
       {{- end }}
 


### PR DESCRIPTION
Follow up PR for https://github.com/istio/installer/pull/83 to update tracing namespace.

Tracing component(zipkin or jaeger), if deployed, should be by default located in istioTelemetry namespace.

