### PR TITLE
[WIP]permit isolated namespaces for integration test in minikube env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ GITBASE ?= "https://github.com"
 ${GOPATH}/src/istio.io/istio:
 	mkdir -p ${GOPATH}/src/istio.io
 	git clone ${GITBASE}/morvencao/istio.git ${GOPATH}/src/istio.io/istio
-	git checkout br_support_isolated_namespace_for_test
+	(cd ${GOPATH}/src/istio.io/istio; git checkout br_support_isolated_namespace_for_test)
 
 ${GOPATH}/src/istio.io/tools:
 	mkdir -p ${GOPATH}/src/istio.io

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,8 @@ GITBASE ?= "https://github.com"
 
 ${GOPATH}/src/istio.io/istio:
 	mkdir -p ${GOPATH}/src/istio.io
-	git clone ${GITBASE}/istio/istio.git ${GOPATH}/src/istio.io/istio
+	git clone ${GITBASE}/morvencao/istio.git ${GOPATH}/src/istio.io/istio
+	git checkout br_support_isolated_namespace_for_test
 
 ${GOPATH}/src/istio.io/tools:
 	mkdir -p ${GOPATH}/src/istio.io

--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,7 @@ GITBASE ?= "https://github.com"
 
 ${GOPATH}/src/istio.io/istio:
 	mkdir -p ${GOPATH}/src/istio.io
-	git clone ${GITBASE}/morvencao/istio.git ${GOPATH}/src/istio.io/istio
-	(cd ${GOPATH}/src/istio.io/istio; git checkout br_support_isolated_namespace_for_test)
+	git clone -b br_support_isolated_namespace_for_test --single-branch ${GITBASE}/morvencao/istio.git ${GOPATH}/src/istio.io/istio
 
 ${GOPATH}/src/istio.io/tools:
 	mkdir -p ${GOPATH}/src/istio.io

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -104,12 +104,12 @@ run-test.integration.kube.presubmit:
 		${GO} test -p 1 -v \
 			istio.io/istio/tests/integration/echo istio.io/istio/tests/integration/... \
     --istio.test.kube.deploy=false --istio.test.kube.minikube  --istio.test.nocleanup \
-	--istio.test.kube.IstioNamespace istio-system \
-	--istio.test.kube.ConfigNamespace ${ISTIO_NS} \
-	--istio.test.kube.TelemetryNamespace ${ISTIO_NS} \
-	--istio.test.kube.PolicyNamespace ${ISTIO_NS} \
-	--istio.test.kube.IngressNamespace ${ISTIO_NS} \
-	--istio.test.kube.EgressNamespace ${ISTIO_NS} \
+	--istio.test.kube.istioNamespace istio-system \
+	--istio.test.kube.configNamespace ${ISTIO_NS} \
+	--istio.test.kube.telemetryNamespace ${ISTIO_NS} \
+	--istio.test.kube.policyNamespace ${ISTIO_NS} \
+	--istio.test.kube.ingressNamespace ${ISTIO_NS} \
+	--istio.test.kube.egressNamespace ${ISTIO_NS} \
 	--istio.test.ci -timeout 30m \
     --istio.test.select +presubmit \
  	--istio.test.env kube \

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -103,7 +103,13 @@ run-test.integration.kube.presubmit:
 	cd ${GOPATH}/src/istio.io/istio; \
 		${GO} test -p 1 -v \
 			istio.io/istio/tests/integration/echo istio.io/istio/tests/integration/... \
-    --istio.test.kube.deploy=false --istio.test.kube.minikube --istio.test.kube.systemNamespace ${ISTIO_NS}  --istio.test.nocleanup \
+    --istio.test.kube.deploy=false --istio.test.kube.minikube  --istio.test.nocleanup \
+	--istio.test.kube.IstioNamespace istio-system \
+	--istio.test.kube.ConfigNamespace ${ISTIO_NS} \
+	--istio.test.kube.TelemetryNamespace ${ISTIO_NS} \
+	--istio.test.kube.PolicyNamespace ${ISTIO_NS} \
+	--istio.test.kube.IngressNamespace ${ISTIO_NS} \
+	--istio.test.kube.EgressNamespace ${ISTIO_NS} \
 	--istio.test.ci -timeout 30m \
     --istio.test.select +presubmit \
  	--istio.test.env kube \


### PR DESCRIPTION
Depends on https://github.com/istio/istio/pull/13830

Resolve: https://github.com/istio/installer/issues/99

Support isolated namespaces for integration test in minikube env.
