### PR TITLE
Add an option to use a self-signed cert for autoinject webhook

### DIFF
--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -88,7 +88,11 @@ spec:
           name: istio
       - name: certs
         secret:
+{{- if .Values.sidecarInjectorWebhook.selfSigned }}
+          secretName: istio-sidecar-injector-self-signed
+{{- else }}
           secretName: istio.istio-sidecar-injector-service-account
+{{- end }}
       - name: inject-config
         configMap:
           name: istio-sidecar-injector

--- a/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
+++ b/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
@@ -1,3 +1,4 @@
+{{- $ca := genCA "istio-sidecar-injector-ca-{{ .Release.Namespace }}" 3650 }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -12,7 +13,11 @@ webhooks:
         name: istio-sidecar-injector
         namespace: {{ .Release.Namespace }}
         path: "/inject"
+{{- if .Values.sidecarInjectorWebhook.selfSigned }}
+      caBundle: {{ $ca.Cert | b64enc }}
+{{- else }}
       caBundle: ""
+{{- end }}
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]
@@ -36,4 +41,24 @@ webhooks:
       matchLabels:
         istio-env: {{ .Release.Namespace }}
 {{- end }}
-
+---
+{{- if .Values.sidecarInjectorWebhook.selfSigned }}
+  {{- $cn := "istio-sidecar-injector" }}
+  {{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}
+  {{- $altName2 := printf "%s.%s.svc" $cn .Release.Namespace }}
+  {{- $altNames := (list $altName1 $altName2) }}
+  {{- $cert := genSignedCert $cn nil $altNames 3650 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-sidecar-injector-self-signed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: sidecar-injector
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  root-cert.pem: {{ $ca.Cert | b64enc }}
+  cert-chain.pem: {{ $cert.Cert | b64enc }}
+  key.pem: {{ $cert.Key | b64enc }}
+{{- end }}

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -16,6 +16,11 @@ sidecarInjectorWebhook:
   # even when mTLS is enabled.
   rewriteAppHTTPProbe: false
 
+  # If true, a self-signed CA will created in order to issue a certificate that
+  # will be used to authenticate the workload respondible for handling
+  # the sidecar-injector webhook.
+  selfSigned: false
+
 # If set, no iptable init will be added. It assumes CNI is installed.
 # TODO: rename to 'enableIptables' or add 'interceptionMode: CNI'
 istio_cni:


### PR DESCRIPTION
Introduces a 'sidecarInjectorWebhook.selfSigned' option to the 'istio-autoinject'
component that allows to generate a self-signed CA and issue a long-lived
certificate during template rendering that can be used to authorize a webhook
workload.