### PR TITLE
use the correct comment to get good docker build

### DIFF
--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -15,7 +15,8 @@ FROM docker:latest as docker
 FROM golang:1.11.5 as golang
 # IMPORTANT: kind releases may or may not work with the 1.14.1 kindest/node tag.
 # We want to create images with multiple k8s versions.
-RUN go get -u sigs.k8s.io/kind  // Use latest since there is not a specific release to match the current kindest/node:v1.14.1 image
+# Use latest since there is not a specific release to match the current kindest/node:v1.14.1 image
+RUN go get -u sigs.k8s.io/kind   
 
 # Used to upload test results to test grid
 RUN go get -u istio.io/test-infra/toolbox/ci2gubernator
@@ -30,7 +31,8 @@ RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin
 RUN chmod +x /usr/local/bin/repo
 
 # create istioctl from `master`, assuming that's what the builder had locally
-RUN go get -d istio.io/istio || true   // ignores `The command '/bin/sh -c go get -d istio.io/istio' returned a non-zero code: 1`
+# ignores `The command '/bin/sh -c go get -d istio.io/istio' returned a non-zero code: 1`
+RUN go get -d istio.io/istio || true   
 RUN cd /go/src/istio.io/istio && make istioctl
 
 ############################################


### PR DESCRIPTION
else it would complain on my machine.

```
Step 3/24 : RUN go get -u sigs.k8s.io/kind  // Use latest since there is not a specific release to match the current kindest/node:v1.14.1 image
 ---> Running in e461839b2a88
package /: /: invalid import path: malformed import path "/": trailing slash
package Use: unrecognized import path "Use" (import path does not begin with hostname)
package latest: unrecognized import path "latest" (import path does not begin with hostname)
package since: unrecognized import path "since" (import path does not begin with hostname)
package there: unrecognized import path "there" (import path does not begin with hostname)
package is: unrecognized import path "is" (import path does not begin with hostname)
package not: unrecognized import path "not" (import path does not begin with hostname)
package a: unrecognized import path "a" (import path does not begin with hostname)
package specific: unrecognized import path "specific" (import path does not begin with hostname)
package release: unrecognized import path "release" (import path does not begin with hostname)
package to: unrecognized import path "to" (import path does not begin with hostname)
package match: unrecognized import path "match" (import path does not begin with hostname)
package the: unrecognized import path "the" (import path does not begin with hostname)
package current: unrecognized import path "current" (import path does not begin with hostname)
package kindest/node:v1.14.1: kindest/node:v1.14.1: invalid import path: malformed import path "kindest/node:v1.14.1": invalid char ':'
```

```
 ---> Running in 6d866be15596
package istio.io/istio: no Go files in /go/src/istio.io/istio
/bin/sh: 1: The: not found```