### PR TITLE
fix: ensure prom operator is not installed in an auto-inject namespace

### DIFF
--- a/test/install.mk
+++ b/test/install.mk
@@ -129,10 +129,13 @@ install-policy:
 	kubectl wait deployments istio-policy -n ${ISTIO_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 
 # This target should only be used in situations in which the prom operator has not already been installed in a cluster.
+install-prometheus-operator: PROM_OP_NS="prometheus-operator"
 install-prometheus-operator:
-	# installs the prom operator in the default namespace
-	kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
-	kubectl wait --for=condition=available --timeout=${WAIT_TIMEOUT} deploy/prometheus-operator
+	kubectl create ns ${PROM_OP_NS} || true
+	kubectl label ns ${PROM_OP_NS} istio-injection=disabled --overwrite
+	curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed "s/namespace: default/namespace: ${PROM_OP_NS}/g" | kubectl apply -n ${PROM_OP_NS} -f -
+	# kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
+	kubectl -n ${PROM_OP_NS} wait --for=condition=available --timeout=${WAIT_TIMEOUT} deploy/prometheus-operator
 
 # This target expects that the prometheus operator (and its CRDs have already been installed).
 # It is provided as a way to install Istio prometheus operator config in isolation.

--- a/test/install.mk
+++ b/test/install.mk
@@ -133,9 +133,10 @@ install-prometheus-operator: PROM_OP_NS="prometheus-operator"
 install-prometheus-operator:
 	kubectl create ns ${PROM_OP_NS} || true
 	kubectl label ns ${PROM_OP_NS} istio-injection=disabled --overwrite
-	curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed "s/namespace: default/namespace: ${PROM_OP_NS}/g" | kubectl apply -n ${PROM_OP_NS} -f -
-	# kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
+	curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed "s/namespace: default/namespace: ${PROM_OP_NS}/g" | kubectl apply -f -
 	kubectl -n ${PROM_OP_NS} wait --for=condition=available --timeout=${WAIT_TIMEOUT} deploy/prometheus-operator
+	kubectl wait crds/prometheuses.monitoring.coreos.com crds/servicemonitors.monitoring.coreos.com --for=condition=established --timeout=${WAIT_TIMEOUT}
+
 
 # This target expects that the prometheus operator (and its CRDs have already been installed).
 # It is provided as a way to install Istio prometheus operator config in isolation.

--- a/test/install.mk
+++ b/test/install.mk
@@ -135,7 +135,8 @@ install-prometheus-operator:
 	kubectl label ns ${PROM_OP_NS} istio-injection=disabled --overwrite
 	curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed "s/namespace: default/namespace: ${PROM_OP_NS}/g" | kubectl apply -f -
 	kubectl -n ${PROM_OP_NS} wait --for=condition=available --timeout=${WAIT_TIMEOUT} deploy/prometheus-operator
-	kubectl wait crds/prometheuses.monitoring.coreos.com crds/servicemonitors.monitoring.coreos.com --for=condition=established --timeout=${WAIT_TIMEOUT}
+	# kubectl wait is problematic, as the CRDs may not exist before the command is issued.
+	until timeout ${WAIT_TIMEOUT} kubectl get crds/prometheuses.monitoring.coreos.com; do echo "Waiting for CRDs to be created..."; done
 
 
 # This target expects that the prometheus operator (and its CRDs have already been installed).

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -133,4 +133,4 @@ run-mysql:
 run-prometheus-operator-config-test: PROM_OPTS="--set prometheus.createPrometheusResource=true"
 run-prometheus-operator-config-test: install-prometheus-operator install-prometheus-operator-config
 	if [ "$$(kubectl -n ${ISTIO_NS} get servicemonitors -o name | wc -l)" -ne "7" ]; then echo "Failure to find ServiceMonitor resouces!"; return 1; fi
-	kubectl -n ${ISTIO_NS} wait pod/prometheus-prometheus-0 --for=condition=Ready --timeout=${WAIT_TIMEOUT}
+	kubectl -n ${ISTIO_NS} wait deploy/prometheus --for=condition=available --timeout=${WAIT_TIMEOUT}


### PR DESCRIPTION
When running a full `make test`, all namespaces are selected for auto-injection, which causes issues with the prom operator install. This PR moves the prom operator to its own namespace and disables auto-injection in that namespace.