### PR TITLE
make pdb immutable.

### DIFF
--- a/gateways/istio-egress/templates/poddisruptionbudget.yaml
+++ b/gateways/istio-egress/templates/poddisruptionbudget.yaml
@@ -2,17 +2,17 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-galley
+  name: egressgateway
   namespace: {{ .Release.Namespace }}
   labels:
-    app: galley
+    app: egressgateway
     release: {{ .Release.Name }}
-    istio: galley
+    istio: egressgateway
 spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: galley
+      app: egressgateway
       release: {{ .Release.Name }}
-      istio: galley
+      istio: egressgateway
 {{- end }}

--- a/gateways/istio-ingress/templates/_podDisruptionBudget.tpl
+++ b/gateways/istio-ingress/templates/_podDisruptionBudget.tpl
@@ -1,8 +1,0 @@
-{{- define "podDisruptionBudget.spec" }}
-{{- if .minAvailable }}
-  minAvailable: {{ .minAvailable }}
-{{- end }}
-{{- if .maxUnavailable }}
-  maxUnavailable: {{ .maxUnavailable }}
-{{- end }}
-{{- end }}

--- a/gateways/istio-ingress/templates/poddisruptionbudget.yaml
+++ b/gateways/istio-ingress/templates/poddisruptionbudget.yaml
@@ -1,17 +1,18 @@
-{{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if $gateway.podDisruptionBudget }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingress
+  name: ingressgateway
   namespace: {{ .Release.Namespace }}
   labels:
-    release: {{ .Release.Name }}
-spec:
-  {{- if $gateway.podDisruptionBudget }}
-  {{ include "podDisruptionBudget.spec" $gateway.podDisruptionBudget }}
-  {{- end }}
-selector:
-  matchLabels:
     app: ingressgateway
+    release: {{ .Release.Name }}
+    istio: ingressgateway
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: ingressgateway
+      release: {{ .Release.Name }}
+      istio: ingressgateway
 {{- end }}

--- a/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -9,12 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     istio: pilot
 spec:
-  {{- if .minAvailable }}
-  minAvailable: {{ .minAvailable }}
-  {{- end }}
-  {{- if .maxUnavailable }}
-  maxUnavailable: {{ .maxUnavailable }}
-  {{- end }}
+  minAvailable: 1
   selector:
     matchLabels:
       app: pilot

--- a/istio-policy/templates/poddisruptionbudget.yaml
+++ b/istio-policy/templates/poddisruptionbudget.yaml
@@ -10,14 +10,11 @@ metadata:
     istio: mixer
     istio-mixer-type: policy
 spec:
-{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
   minAvailable: 1
-{{- end }}
   selector:
     matchLabels:
       app: istio-policy
       release: {{ .Release.Name }}
       istio: mixer
       istio-mixer-type: policy
----
 {{- end }}

--- a/istio-telemetry/mixer-telemetry/templates/poddisruptionbudget.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/poddisruptionbudget.yaml
@@ -2,17 +2,19 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-galley
+  name: istio-telemetry
   namespace: {{ .Release.Namespace }}
   labels:
-    app: galley
+    app: istio-telemetry
     release: {{ .Release.Name }}
-    istio: galley
+    istio: mixer
+    istio-mixer-type: telemetry
 spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: galley
+      app: istio-telemetry
       release: {{ .Release.Name }}
-      istio: galley
+      istio: mixer
+      istio-mixer-type: telemetry
 {{- end }}

--- a/test/noauth.mk
+++ b/test/noauth.mk
@@ -57,12 +57,10 @@ run-test-noauth-full: install-crds
 	bin/iop ${ISTIO_NS} istio-ingress ${BASE}/gateways/istio-ingress ${INSTALL_OPTS} ${IOP_OPTS} \
 		 --set global.controlPlaneSecurityEnabled=false
 	kubectl wait deployments ingressgateway -n ${ISTIO_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
-	bin/iop ${ISTIO_NS} istio-telemetry ${BASE}/istio-telemetry/mixer-telemetry ${IOP_OPTS} \
+	bin/iop ${ISTIO_NS} istio-telemetry ${BASE}/istio-telemetry/mixer-telemetry --set global.istioNamespace=${ISTIO_NS} ${IOP_OPTS} \
          --set global.controlPlaneSecurityEnabled=false ${INSTALL_OPTS}
 	bin/iop ${ISTIO_NS} istio-prometheus ${BASE}/istio-telemetry/prometheus/ --set global.istioNamespace=${ISTIO_NS} ${IOP_OPTS} \
 		 --set global.controlPlaneSecurityEnabled=false --set prometheus.security.enabled=false ${INSTALL_OPTS}
-	bin/iop ${ISTIO_NS} istio-mixer ${BASE}/istio-telemetry/mixer-telemetry/ --set global.istioNamespace=${ISTIO_NS} ${IOP_OPTS} \
-		--set global.controlPlaneSecurityEnabled=false ${INSTALL_OPTS}
 
 	kubectl wait deployments istio-telemetry prometheus -n ${ISTIO_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 


### PR DESCRIPTION
IIRC, we have a limitation about the `PodDisruptionBudget `, see: https://github.com/istio/istio/issues/11210

@linsun @sdake We still can need the immutable pdb with `kubectl apply...`, right?