### PR TITLE
exclude tracing test.

### DIFF
--- a/test/tests.mk
+++ b/test/tests.mk
@@ -77,7 +77,7 @@ run-mixer:
 		E2E_ARGS="${E2E_ARGS} --namespace=mixertest")
 
 # Test targets to run. Exclude tests that are broken for now
-INT_TARGETS = $(shell GOPATH=${GOPATH} go list ../istio/tests/integration/... | grep -v /mixer/policy)
+INT_TARGETS = $(shell GOPATH=${GOPATH} go list ../istio/tests/integration/... | grep -v "/mixer/policy\|telemetry/tracing")
 
 INT_FLAGS ?= \
 	--istio.test.hub ${HUB} \


### PR DESCRIPTION
Tracing test has been added in main repo: https://github.com/istio/istio/pull/13790, the new installer hasn't imported tracing component, we need to temporarily exclude that.