### PR TITLE
Add label to telemetry service

### DIFF
--- a/istio-telemetry/mixer-telemetry/templates/service.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-telemetry
+    istio: mixer
     release: {{ .Release.Name }}
 spec:
   ports:


### PR DESCRIPTION
This is needed for prometheus to scrape it properly.