### PR TITLE
Use daily master for installer pipeline instead of 1.1

### DIFF
--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -12,12 +12,13 @@ resources:
     type: git
     source:
       uri: "https://github.com/istio/istio-installer"
+
   - name: istio-master
     type: git
     source:
       uri: "https://github.com/istio/istio"
       branch: master
-      
+
 jobs:
   - name: install
     serial_groups: [ cluster ]
@@ -45,9 +46,9 @@ jobs:
             git remote -v
             git branch
 
-    - task: install-master-daily
-      params: &params-master-daily
-        TAG: master-latest-daily
+    - task: install-master
+      params:
+        TAG: master-daily
         HUB: gcr.io/istio-release
         KUBECONFIG: ((KUBECONFIG))
         # Remove overly generous resource request to avoid unnecessarily scaling up k8s nodes
@@ -81,141 +82,6 @@ jobs:
     - get: 24h
       trigger: true
       passed: [install]
-    - task: install-bookinfo
-      params:
-        KUBECONFIG: ((KUBECONFIG))
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: gcr.io/peripli/istio-base
-        inputs:
-          - name: istio-master
-            path: src/github.com/istio/istio
-          - name: istio-installer
-        run:
-          path: /bin/sh
-          args:
-          - -ec
-          - |
-            echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
-            export KUBECONFIG=/tmp/kubeconfig.yaml
-            istio-installer/bin/test.sh --skip-cleanup src/github.com/istio/istio/
-
-  - name: install-release-1.1
-    serial_groups: [ cluster ]
-    plan:
-    - get: 24h
-      trigger: true
-      passed: [ test-after-install ]
-    - get: istio-installer
-      trigger: true
-      passed: [ test-after-install ]
-
-    - task: install-release-1.1
-      params: &params-1-1-daily
-        TAG: release-1.1-latest-daily
-        HUB: gcr.io/istio-release
-        RESOURCES_FLAGS: "--set global.resources.requests.cpu=0m --set resources.requests.cpu=0 --set resources.requests.memory=0 --set global.proxy.resources.requests.cpu=0 --set global.proxy.resources.requests.memory=0"
-        KUBECONFIG: ((KUBECONFIG))
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: gcr.io/peripli/istio-base
-        inputs:
-          - name: istio-installer
-        run:
-          path: /bin/sh
-          args:
-          - -ec
-          - |
-            # see github issue #65, so we take an older version that works with 1.1
-            cd istio-installer
-            git fetch origin master
-            git checkout 02d6d54442fb1f48528742a40a37c3a37888db79
-            cd ..
-
-            echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
-            export KUBECONFIG=/tmp/kubeconfig.yaml
-            istio-installer/bin/cleanup.sh
-            istio-installer/bin/install.sh
-    
-  - name: test-after-install-release-1.1
-    serial_groups: [ cluster ]
-    plan:
-    - get: istio-installer
-      passed: [ install-release-1.1 ]
-      trigger: true
-    - get: istio-master
-      trigger: false
-    - get: 24h
-      trigger: true
-      passed: [ install-release-1.1 ]
-    - task: install-bookinfo
-      params:
-        KUBECONFIG: ((KUBECONFIG))
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: gcr.io/peripli/istio-base
-        inputs:
-          - name: istio-master
-            path: src/github.com/istio/istio
-          - name: istio-installer
-        run:
-          path: /bin/sh
-          args:
-          - -ec
-          - |
-            echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
-            export KUBECONFIG=/tmp/kubeconfig.yaml
-            istio-installer/bin/test.sh --skip-cleanup src/github.com/istio/istio/
-
-  - name: update
-    serial_groups: [ cluster ]
-    plan:
-    - get: 24h
-      trigger: true
-      passed: [ test-after-install-release-1.1 ]
-    - get: istio-installer
-      passed: [ test-after-install-release-1.1 ]
-      trigger: true
-    - task: update-master-daily
-      config:
-        platform: linux
-        params: *params-master-daily
-        image_resource:
-          type: docker-image
-          source:
-            repository: gcr.io/peripli/istio-base
-        inputs:
-          - name: istio-installer
-        run:
-          path: /bin/sh
-          args:
-          - -ec
-          - |
-            echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
-            export KUBECONFIG=/tmp/kubeconfig.yaml
-            export REMOVE_OLD_CONTROL=true
-            istio-installer/bin/install.sh
-            istio-installer/bin/install.sh switch_istio_control
-  
-  - name: test-after-update
-    serial_groups: [ cluster ]
-    plan:
-    - get: 24h
-      trigger: true
-      passed: [ update ]
-    - get: istio-installer
-      passed: [ update ]
-      trigger: true
-    - get: istio-master
     - task: install-bookinfo
       params:
         KUBECONFIG: ((KUBECONFIG))

--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -103,7 +103,7 @@ jobs:
             export KUBECONFIG=/tmp/kubeconfig.yaml
             istio-installer/bin/test.sh --skip-cleanup src/github.com/istio/istio/
 
-  - name: install-old-master # we probably want 1.1 here, but we would need an old installer
+  - name: install-release-1.1
     serial_groups: [ cluster ]
     plan:
     - get: 24h
@@ -113,9 +113,9 @@ jobs:
       trigger: true
       passed: [ test-after-install ]
 
-    - task: install-old-master
-      params: &params-master-old
-        TAG: master-20190506-09-16
+    - task: install-release-1.1
+      params: &params-1-1-daily
+        TAG: release-1.1-latest-daily
         HUB: gcr.io/istio-release
         RESOURCES_FLAGS: "--set global.resources.requests.cpu=0m --set resources.requests.cpu=0 --set resources.requests.memory=0 --set global.proxy.resources.requests.cpu=0 --set global.proxy.resources.requests.memory=0"
         KUBECONFIG: ((KUBECONFIG))
@@ -132,22 +132,28 @@ jobs:
           args:
           - -ec
           - |
+            # see github issue #65, so we take an older version that works with 1.1
+            cd istio-installer
+            git fetch origin master
+            git checkout 02d6d54442fb1f48528742a40a37c3a37888db79
+            cd ..
+
             echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
             export KUBECONFIG=/tmp/kubeconfig.yaml
             istio-installer/bin/cleanup.sh
             istio-installer/bin/install.sh
     
-  - name: test-after-install-old-master
+  - name: test-after-install-release-1.1
     serial_groups: [ cluster ]
     plan:
     - get: istio-installer
-      passed: [ install-old-master ]
+      passed: [ install-release-1.1 ]
       trigger: true
     - get: istio-master
       trigger: false
     - get: 24h
       trigger: true
-      passed: [ install-old-master ]
+      passed: [ install-release-1.1 ]
     - task: install-bookinfo
       params:
         KUBECONFIG: ((KUBECONFIG))
@@ -175,9 +181,9 @@ jobs:
     plan:
     - get: 24h
       trigger: true
-      passed: [ test-after-install-old-master ]
+      passed: [ test-after-install-release-1.1 ]
     - get: istio-installer
-      passed: [ test-after-install-old-master ]
+      passed: [ test-after-install-release-1.1 ]
       trigger: true
     - task: update-master-daily
       config:

--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - task: install-master
       params:
-        TAG: master-daily
+        TAG: master-latest-daily
         HUB: gcr.io/istio-release
         KUBECONFIG: ((KUBECONFIG))
         # Remove overly generous resource request to avoid unnecessarily scaling up k8s nodes

--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -12,11 +12,11 @@ resources:
     type: git
     source:
       uri: "https://github.com/istio/istio-installer"
-  - name: istio-release-1.1
+  - name: istio-master
     type: git
     source:
       uri: "https://github.com/istio/istio"
-      branch: release-1.1
+      branch: master
       
 jobs:
   - name: install
@@ -45,9 +45,9 @@ jobs:
             git remote -v
             git branch
 
-    - task: install-1-1-daily
-      params: &params-1-1-daily
-        TAG: release-1.1-latest-daily
+    - task: install-master-daily
+      params: &params-master-daily
+        TAG: master-latest-daily
         HUB: gcr.io/istio-release
         KUBECONFIG: ((KUBECONFIG))
         # Remove overly generous resource request to avoid unnecessarily scaling up k8s nodes
@@ -76,7 +76,7 @@ jobs:
     - get: istio-installer
       passed: [ install ]
       trigger: true
-    - get: istio-release-1.1
+    - get: istio-master
       trigger: false
     - get: 24h
       trigger: true
@@ -91,7 +91,7 @@ jobs:
           source:
             repository: gcr.io/peripli/istio-base
         inputs:
-          - name: istio-release-1.1
+          - name: istio-master
             path: src/github.com/istio/istio
           - name: istio-installer
         run:
@@ -103,22 +103,22 @@ jobs:
             export KUBECONFIG=/tmp/kubeconfig.yaml
             istio-installer/bin/test.sh --skip-cleanup src/github.com/istio/istio/
 
-  - name: install-1.1.0
+  - name: install-old-master # we probably want 1.1 here, but we would need an old installer
     serial_groups: [ cluster ]
     plan:
     - get: 24h
       trigger: true
-      passed: [test-after-install]
+      passed: [ test-after-install ]
     - get: istio-installer
       trigger: true
-      passed: [test-after-install]
+      passed: [ test-after-install ]
 
-    - task: install-1-1-0
-      params: &install-params-1-1-0
-        TAG: 1.1.0
-        HUB: istio
-        KUBECONFIG: ((KUBECONFIG))
+    - task: install-old-master
+      params: &params-master-old
+        TAG: master-20190506-09-16
+        HUB: gcr.io/istio-release
         RESOURCES_FLAGS: "--set global.resources.requests.cpu=0m --set resources.requests.cpu=0 --set resources.requests.memory=0 --set global.proxy.resources.requests.cpu=0 --set global.proxy.resources.requests.memory=0"
+        KUBECONFIG: ((KUBECONFIG))
       config:
         platform: linux
         image_resource:
@@ -137,17 +137,17 @@ jobs:
             istio-installer/bin/cleanup.sh
             istio-installer/bin/install.sh
     
-  - name: test-after-install-1.1.0
+  - name: test-after-install-old-master
     serial_groups: [ cluster ]
     plan:
     - get: istio-installer
-      passed: [ install-1.1.0 ]
+      passed: [ install-old-master ]
       trigger: true
-    - get: istio-release-1.1
+    - get: istio-master
       trigger: false
     - get: 24h
       trigger: true
-      passed: [install-1.1.0]
+      passed: [ install-old-master ]
     - task: install-bookinfo
       params:
         KUBECONFIG: ((KUBECONFIG))
@@ -158,7 +158,7 @@ jobs:
           source:
             repository: gcr.io/peripli/istio-base
         inputs:
-          - name: istio-release-1.1
+          - name: istio-master
             path: src/github.com/istio/istio
           - name: istio-installer
         run:
@@ -175,14 +175,14 @@ jobs:
     plan:
     - get: 24h
       trigger: true
-      passed: [test-after-install-1.1.0]
+      passed: [ test-after-install-old-master ]
     - get: istio-installer
-      passed: [test-after-install-1.1.0]
+      passed: [ test-after-install-old-master ]
       trigger: true
-    - task: update-1-1-daily
+    - task: update-master-daily
       config:
         platform: linux
-        params: *params-1-1-daily
+        params: *params-master-daily
         image_resource:
           type: docker-image
           source:
@@ -205,11 +205,11 @@ jobs:
     plan:
     - get: 24h
       trigger: true
-      passed: [update]
+      passed: [ update ]
     - get: istio-installer
-      passed: [update]
+      passed: [ update ]
       trigger: true
-    - get: istio-release-1.1
+    - get: istio-master
     - task: install-bookinfo
       params:
         KUBECONFIG: ((KUBECONFIG))
@@ -220,7 +220,7 @@ jobs:
           source:
             repository: gcr.io/peripli/istio-base
         inputs:
-          - name: istio-release-1.1
+          - name: istio-master
             path: src/github.com/istio/istio
           - name: istio-installer
         run:

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -183,9 +183,13 @@ case "$COMMAND" in
     install_cni) install_cni ;;
     install_kiali) install_kiali ;;
     switch_istio_control) switch_istio_control ;;
-    install_all) install_crds &&  install_system && install_control && install_ingress && install_telemetry ;;
+    install_all)
+        install_crds
+        install_system
+        install_control
+        install_ingress
+        install_telemetry ;;
 esac
 
-# Temporarily disabled - fails in circle:  && switch_istio_control
 
 echo "Finished"


### PR DESCRIPTION
The install of 1.1 is not supported, so I have adjusted the pipeline to

* install daily-master
* test
* install old (fixed) version of master #until 1.2 was released
* test
* update to daily master
* test