### PR TITLE
fix error in make target "build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,8 @@ test: info dep maybe-clean maybe-prepare sync docker-run-test maybe-clean
 
 # Build all templates inside the hermetic docker image. Tools are installed.
 build:
-	docker run -it --rm -v ${GOPATH}:${GOPATH} --entrypoint /bin/bash $(BUILD_IMAGE) \
-		-e GOPATH=${GOPATH} \
+	docker run -it --rm -v ${GOPATH}:${GOPATH} --entrypoint /bin/bash -e GOPATH=${GOPATH} \
+		$(BUILD_IMAGE) \
 		-c "cd ${GOPATH}/src/istio.io/installer; ls; make run-build"
 
 # Run a command in the docker image running kind. Command passed as "TARGET" env.


### PR DESCRIPTION
The order of parameters to `docker run` was wrong. As a result, bash tried to execute the file `GOPATH=${GOPATH}` instead of forwarding the environment variable into the container.
```bash
$ make build
docker run -it --rm -v /Users/istio/go:/Users/istio/go --entrypoint /bin/bash istionightly/kind:v1.14.1-1 \
		-e GOPATH=/Users/istio/go \
		-c "cd /Users/istio/go/src/istio.io/installer; ls; make run-build"
/bin/bash: GOPATH=/Users/istio/go: No such file or directory
make: *** [build] Error 1
```