### PR TITLE
Allow bin/iop to be sourced without exiting bash

### DIFF
--- a/bin/iop
+++ b/bin/iop
@@ -2,6 +2,7 @@
 
 # Example script to install - will be replaced by operator or other tools, used for testing and as sample.
 
+RESTORE_SET_X=$(shopt -po xtrace)
 set -x
 
 BASE=${BASE:-`pwd`}
@@ -83,6 +84,15 @@ function render_kube_yaml() {
         fi
 }
 
+IBASE=${IBASE:-`pwd`}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    # The script is being sourced.
+    $RESTORE_SET_X
+    unset RESTORE_SET_X
+    return
+fi
+
 if [ "$1" == "" ] ; then
     echo "iop NAMESPACE COMPONENT CONFIGDIR [-t|-d] [HELM_TEMPLATE_OPTIONS]"
     echo ""
@@ -97,8 +107,6 @@ if [ "$1" == "" ] ; then
     echo ""
     exit 1
 fi
-
-IBASE=${IBASE:-`pwd`}
 
 iop $*
 


### PR DESCRIPTION
Our README is full of commands like this `iop istio-control istio-autoinject $IBASE/istio-control/istio-autoinject --set enableNamespacesByDefault=true` which in my understanding require bin/iop to be sourced first. This worked fine in the past, but is no longer possible as iop calls `exit 1` when called without arguments.

This PR enables sourcing of iop again:
- If the script is being sourced, it will call `return` after all functions and variables (e.g. `$IBASE`) are set.
- Additionally, before calling `set -x` the current state of xtrace is stored and restored later.