### PR TITLE
Add neverInjectSelector and alwaysInjectSelector properties to Helm chart

### DIFF
--- a/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
+++ b/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
@@ -15,8 +15,8 @@ data:
   config: |-
     policy: {{ .Values.global.proxy.autoInject }}
     alwaysInjectSelector:
-{{ toYaml .Values.sidecarInjectorWebhook.alwaysInjectSelector | indent 20}}
+{{ toYaml .Values.sidecarInjectorWebhook.alwaysInjectSelector | indent 6 }}
     neverInjectSelector:
-{{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | indent 20 }}
+{{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | indent 6 }}
 {{ .Files.Get "files/injection-template.yaml" | indent 4 }}
 {{- end }}

--- a/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
+++ b/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
@@ -14,5 +14,9 @@ data:
 
   config: |-
     policy: {{ .Values.global.proxy.autoInject }}
+    alwaysInjectSelector:
+{{ toYaml .Values.sidecarInjectorWebhook.alwaysInjectSelector | indent 20}}
+    neverInjectSelector:
+{{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | indent 20 }}
 {{ .Files.Get "files/injection-template.yaml" | indent 4 }}
 {{- end }}

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -42,6 +42,14 @@ sidecarInjectorWebhook:
   podAntiAffinityLabelSelector: []
   podAntiAffinityTermLabelSelector: []
 
+  # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
+  # always skip the injection on pods that match that label selector, regardless of the global policy.
+  # See https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions
+
+  neverInjectSelector: []
+
+  alwaysInjectSelector: []
+
 # If set, no iptable init will be added. It assumes CNI is installed.
 # TODO: rename to 'enableIptables' or add 'interceptionMode: CNI'
 istio_cni:


### PR DESCRIPTION
Capability to specify alwaysInjectSelector and neverInjectSelector in the Helm chart.

Resolves istio/istio#14020