### PR TITLE
add nodeSelector and toleration.

### DIFF
--- a/gateways/istio-egress/templates/_affinity.tpl
+++ b/gateways/istio-egress/templates/_affinity.tpl
@@ -14,15 +14,22 @@
         - key: beta.kubernetes.io/arch
           operator: In
           values:
-        {{- range $key, $val := .Values.global.arch }}
+        {{- range $key, $val := .global.arch }}
           {{- if gt ($val | int) 0 }}
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .global.defaultNodeSelector .nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
-  {{- range $key, $val := .Values.global.arch }}
+  {{- range $key, $val := .global.arch }}
     {{- if gt ($val | int) 0 }}
     - weight: {{ $val | int }}
       preference:
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .podAntiAffinityTermLabelSelector}}
+    {{- if .podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -248,6 +248,12 @@ spec:
           optional: true
       {{- end }}
       affinity:
-      {{- include "nodeaffinity" $ | indent 6 }}
+      {{- include "nodeaffinity" (dict "global" .Values.global "nodeSelector" $gateway.nodeSelector) | indent 6 }}
       {{- include "podAntiAffinity" $gateway | indent 6 }}
----
+{{- if $gateway.tolerations }}
+      tolerations:
+{{ toYaml $gateway.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -253,7 +253,4 @@ spec:
 {{- if $gateway.tolerations }}
       tolerations:
 {{ toYaml $gateway.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/gateways/istio-egress/values.yaml
+++ b/gateways/istio-egress/values.yaml
@@ -72,6 +72,7 @@ gateways:
     ISTIO_META_ROUTER_MODE: "sni-dnat"
 
     nodeSelector: {}
+    tolerations: []
 
     # Specify the pod anti-affinity that allows you to constrain which nodes
     # your pod is eligible to be scheduled based on labels on pods that are

--- a/gateways/istio-ingress/templates/_affinity.tpl
+++ b/gateways/istio-ingress/templates/_affinity.tpl
@@ -14,12 +14,12 @@
         - key: beta.kubernetes.io/arch
           operator: In
           values:
-        {{- range $key, $val := .Values.global.arch }}
+        {{- range $key, $val := .global.arch }}
           {{- if gt ($val | int) 0 }}
           - {{ $key }}
           {{- end }}
         {{- end }}
-        {{- $nodeSelector := default .Values.global.defaultNodeSelector .nodeSelector -}}
+        {{- $nodeSelector := default .global.defaultNodeSelector .nodeSelector -}}
         {{- range $key, $val := $nodeSelector }}
         - key: {{ $key }}
           operator: In
@@ -29,7 +29,7 @@
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
-  {{- range $key, $val := .Values.global.arch }}
+  {{- range $key, $val := .global.arch }}
     {{- if gt ($val | int) 0 }}
     - weight: {{ $val | int }}
       preference:
@@ -49,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .podAntiAffinityTermLabelSelector}}
+    {{- if .podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -258,7 +258,4 @@ spec:
 {{- if $gateway.tolerations }}
       tolerations:
 {{ toYaml $gateway.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -253,8 +253,12 @@ spec:
           optional: true
       {{- end }}
       affinity:
-{{- if .Values.global.arch }}
-      {{- include "nodeaffinity" $ | indent 6 }}
-{{- end }}
+      {{- include "nodeaffinity" (dict "global" .Values.global "nodeSelector" $gateway.nodeSelector) | indent 6 }}
       {{- include "podAntiAffinity" $gateway | indent 6 }}
----
+{{- if $gateway.tolerations }}
+      tolerations:
+{{ toYaml $gateway.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/gateways/istio-ingress/values.yaml
+++ b/gateways/istio-ingress/values.yaml
@@ -109,6 +109,9 @@ gateways:
       # enable cross cluster routing.
       ISTIO_META_ROUTER_MODE: "sni-dnat"
 
+    nodeSelector: {}
+    tolerations: []
+
     # Specify the pod anti-affinity that allows you to constrain which nodes
     # your pod is eligible to be scheduled based on labels on pods that are
     # already running on the node rather than based on labels on nodes.

--- a/global.yaml
+++ b/global.yaml
@@ -251,6 +251,12 @@ global:
   # the desired values.
   defaultNodeSelector: {}
 
+  # Default node tolerations to be applied to all deployments so that all pods can be 
+  # scheduled to a particular nodes. Each component can overwrite these default 
+  # values by adding its tolerations block in the relevant section below and setting 
+  # the desired values.
+  defaultTolerations: []
+
   # Whether to perform server-side validation of configuration.
   configValidation: true
 

--- a/global.yaml
+++ b/global.yaml
@@ -251,12 +251,6 @@ global:
   # the desired values.
   defaultNodeSelector: {}
 
-  # Default node tolerations to be applied to all deployments so that all pods can be 
-  # scheduled to a particular nodes. Each component can overwrite these default 
-  # values by adding its tolerations block in the relevant section below and setting 
-  # the desired values.
-  defaultTolerations: []
-
   # Whether to perform server-side validation of configuration.
   configValidation: true
 

--- a/istio-control/istio-autoinject/templates/_affinity.tpl
+++ b/istio-control/istio-autoinject/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.sidecarInjectorWebhook.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.sidecarInjectorWebhook.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.sidecarInjectorWebhook.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -104,3 +104,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.sidecarInjectorWebhook.tolerations }}
+      tolerations:
+{{ toYaml .Values.sidecarInjectorWebhook.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -107,7 +107,4 @@ spec:
 {{- if .Values.sidecarInjectorWebhook.tolerations }}
       tolerations:
 {{ toYaml .Values.sidecarInjectorWebhook.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -21,6 +21,9 @@ sidecarInjectorWebhook:
   # the sidecar-injector webhook.
   selfSigned: false
 
+  nodeSelector: {}
+  tolerations: []
+
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.
@@ -47,7 +50,6 @@ sidecarInjectorWebhook:
   # See https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions
 
   neverInjectSelector: []
-
   alwaysInjectSelector: []
 
 # If set, no iptable init will be added. It assumes CNI is installed.

--- a/istio-control/istio-config/templates/_affinity.tpl
+++ b/istio-control/istio-config/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.galley.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.galley.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.galley.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -178,7 +178,4 @@ spec:
 {{- if .Values.galley.tolerations }}
       tolerations:
 {{ toYaml .Values.galley.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -175,3 +175,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.galley.tolerations }}
+      tolerations:
+{{ toYaml .Values.galley.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/istio-control/istio-config/values.yaml
+++ b/istio-control/istio-config/values.yaml
@@ -13,6 +13,9 @@ galley:
   # TODO: Galley appears to use the mesh config - need to find which fields are used and need to be configured.
   mesh: {}
 
+  nodeSelector: {}
+  tolerations: []
+
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.

--- a/istio-control/istio-discovery/templates/_affinity.tpl
+++ b/istio-control/istio-discovery/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.pilot.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.pilot.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.pilot.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -214,3 +214,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.pilot.tolerations }}
+      tolerations:
+{{ toYaml .Values.pilot.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -217,7 +217,4 @@ spec:
 {{- if .Values.pilot.tolerations }}
       tolerations:
 {{ toYaml .Values.pilot.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -26,6 +26,9 @@ pilot:
   cpu:
     targetAverageUtilization: 80
 
+  nodeSelector: {}
+  tolerations: []
+
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.

--- a/istio-policy/templates/_affinity.tpl
+++ b/istio-policy/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.mixer.policy.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -36,13 +43,13 @@
 {{- end }}
 
 {{- define "podAntiAffinity" }}
-{{- if or .Values.mixer.podAntiAffinityLabelSelector .Values.mixer.podAntiAffinityTermLabelSelector}}
+{{- if or .Values.mixer.policy.podAntiAffinityLabelSelector .Values.mixer.policy.podAntiAffinityTermLabelSelector}}
   podAntiAffinity:
-    {{- if .Values.mixer.podAntiAffinityLabelSelector }}
+    {{- if .Values.mixer.policy.podAntiAffinityLabelSelector }}
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.mixer.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.mixer.policy.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}
@@ -50,7 +57,7 @@
 {{- end }}
 
 {{- define "podAntiAffinityRequiredDuringScheduling" }}
-    {{- range $index, $item := .Values.mixer.podAntiAffinityLabelSelector }}
+    {{- range $index, $item := .Values.mixer.policy.podAntiAffinityLabelSelector }}
     - labelSelector:
         matchExpressions:
         - key: {{ $item.key }}
@@ -67,7 +74,7 @@
 {{- end }}
 
 {{- define "podAntiAffinityPreferredDuringScheduling" }}
-    {{- range $index, $item := .Values.mixer.podAntiAffinityTermLabelSelector }}
+    {{- range $index, $item := .Values.mixer.policy.podAntiAffinityTermLabelSelector }}
     - podAffinityTerm:
         labelSelector:
           matchExpressions:

--- a/istio-policy/templates/config.yaml
+++ b/istio-policy/templates/config.yaml
@@ -199,7 +199,7 @@ spec:
     destination.workload.namespace:
       valueType: STRING
 ---
-{{- if .Values.mixer.adapters.kubernetesenv.enabled }}
+{{- if .Values.mixer.policy.adapters.kubernetesenv.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -66,9 +66,6 @@ spec:
 {{- if .Values.mixer.policy.tolerations }}
       tolerations:
 {{ toYaml .Values.mixer.policy.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}
       containers:
       - name: mixer

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -63,6 +63,13 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.mixer.policy.tolerations }}
+      tolerations:
+{{ toYaml .Values.mixer.policy.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}
       containers:
       - name: mixer
 {{- if contains "/" .Values.mixer.policy.image }}
@@ -91,7 +98,7 @@ spec:
           - --configStoreURL=k8s://
 {{- end }}
           - --configDefaultNamespace={{ .Values.global.configNamespace }}
-          {{- if .Values.mixer.adapters.useAdapterCRDs }}
+          {{- if .Values.mixer.policy.adapters.useAdapterCRDs }}
           - --useAdapterCRDs=true
           {{- else }}
           - --useAdapterCRDs=false
@@ -102,9 +109,9 @@ spec:
           {{- else }}
           - --trace_zipkin_url=http://zipkin.{{ .Values.global.telemetryNamespace }}:9411/api/v1/spans
           {{- end }}
-        {{- if .Values.mixer.env }}
+        {{- if .Values.mixer.policy.env }}
         env:
-        {{- range $key, $val := .Values.mixer.env }}
+        {{- range $key, $val := .Values.mixer.policy.env }}
         - name: {{ $key }}
           value: "{{ $val }}"
         {{- end }}

--- a/istio-policy/values.yaml
+++ b/istio-policy/values.yaml
@@ -1,9 +1,6 @@
-
-
 mixer:
   policy:
     image: mixer
-
 
     replicaCount: 1
     autoscaleEnabled: true
@@ -14,30 +11,33 @@ mixer:
 
     podAnnotations: {}
 
-  env:
-    GODEBUG: gctrace=1
+    env:
+      GODEBUG: gctrace=1
 
-  adapters:
-    kubernetesenv:
-      enabled: true
+    adapters:
+      kubernetesenv:
+        enabled: true
 
-  # Specify the pod anti-affinity that allows you to constrain which nodes
-  # your pod is eligible to be scheduled based on labels on pods that are
-  # already running on the node rather than based on labels on nodes.
-  # There are currently two types of anti-affinity:
-  #    "requiredDuringSchedulingIgnoredDuringExecution"
-  #    "preferredDuringSchedulingIgnoredDuringExecution"
-  # which denote “hard” vs. “soft” requirements, you can define your values
-  # in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
-  # correspondingly.
-  # For example:
-  # podAntiAffinityLabelSelector:
-  # - key: security
-  #   operator: In
-  #   values: S1,S2
-  #   topologyKey: "kubernetes.io/hostname"
-  # This pod anti-affinity rule says that the pod requires not to be scheduled
-  # onto a node if that node is already running a pod with label having key
-  # “security” and value “S1”.
-  podAntiAffinityLabelSelector: []
-  podAntiAffinityTermLabelSelector: []
+    nodeSelector: {}
+    tolerations: []
+
+    # Specify the pod anti-affinity that allows you to constrain which nodes
+    # your pod is eligible to be scheduled based on labels on pods that are
+    # already running on the node rather than based on labels on nodes.
+    # There are currently two types of anti-affinity:
+    #    "requiredDuringSchedulingIgnoredDuringExecution"
+    #    "preferredDuringSchedulingIgnoredDuringExecution"
+    # which denote “hard” vs. “soft” requirements, you can define your values
+    # in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+    # correspondingly.
+    # For example:
+    # podAntiAffinityLabelSelector:
+    # - key: security
+    #   operator: In
+    #   values: S1,S2
+    #   topologyKey: "kubernetes.io/hostname"
+    # This pod anti-affinity rule says that the pod requires not to be scheduled
+    # onto a node if that node is already running a pod with label having key
+    # “security” and value “S1”.
+    podAntiAffinityLabelSelector: []
+    podAntiAffinityTermLabelSelector: []

--- a/istio-telemetry/grafana/templates/_affinity.tpl
+++ b/istio-telemetry/grafana/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.grafana.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.grafana.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.grafana.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/istio-telemetry/grafana/templates/deployment.yaml
+++ b/istio-telemetry/grafana/templates/deployment.yaml
@@ -99,9 +99,6 @@ spec:
 {{- if .Values.grafana.tolerations }}
       tolerations:
 {{ toYaml .Values.grafana.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}
       volumes:
       - name: config

--- a/istio-telemetry/grafana/templates/deployment.yaml
+++ b/istio-telemetry/grafana/templates/deployment.yaml
@@ -96,6 +96,13 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.grafana.tolerations }}
+      tolerations:
+{{ toYaml .Values.grafana.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:

--- a/istio-telemetry/grafana/values.yaml
+++ b/istio-telemetry/grafana/values.yaml
@@ -66,6 +66,9 @@ grafana:
           options:
             path: /var/lib/grafana/dashboards/istio
 
+  nodeSelector: {}
+  tolerations: []
+
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.

--- a/istio-telemetry/mixer-telemetry/templates/_affinity.tpl
+++ b/istio-telemetry/mixer-telemetry/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.mixer.telemetry.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -36,13 +43,13 @@
 {{- end }}
 
 {{- define "podAntiAffinity" }}
-{{- if or .Values.mixer.podAntiAffinityLabelSelector .Values.mixer.podAntiAffinityTermLabelSelector}}
+{{- if or .Values.mixer.telemetry.podAntiAffinityLabelSelector .Values.mixer.telemetry.podAntiAffinityTermLabelSelector}}
   podAntiAffinity:
-    {{- if .Values.mixer.podAntiAffinityLabelSelector }}
+    {{- if .Values.mixer.telemetry.podAntiAffinityLabelSelector }}
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.mixer.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.mixer.telemetry.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}
@@ -50,7 +57,7 @@
 {{- end }}
 
 {{- define "podAntiAffinityRequiredDuringScheduling" }}
-    {{- range $index, $item := .Values.mixer.podAntiAffinityLabelSelector }}
+    {{- range $index, $item := .Values.mixer.telemetry.podAntiAffinityLabelSelector }}
     - labelSelector:
         matchExpressions:
         - key: {{ $item.key }}
@@ -67,7 +74,7 @@
 {{- end }}
 
 {{- define "podAntiAffinityPreferredDuringScheduling" }}
-    {{- range $index, $item := .Values.mixer.podAntiAffinityTermLabelSelector }}
+    {{- range $index, $item := .Values.mixer.telemetry.podAntiAffinityTermLabelSelector }}
     - podAffinityTerm:
         labelSelector:
           matchExpressions:

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -41,14 +41,16 @@ spec:
       - name: telemetry-envoy-config
         configMap:
           name: telemetry-envoy-config
-
-    {{- if .Values.mixer.telemetry.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.mixer.telemetry.nodeSelector | indent 8 }}
-    {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.mixer.telemetry.tolerations }}
+      tolerations:
+{{ toYaml .Values.mixer.telemetry.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}
       containers:
       - name: mixer
 {{- if contains "/" .Values.mixer.telemetry.image }}

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -47,9 +47,6 @@ spec:
 {{- if .Values.mixer.telemetry.tolerations }}
       tolerations:
 {{ toYaml .Values.mixer.telemetry.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}
       containers:
       - name: mixer

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -36,23 +36,26 @@ mixer:
       # Setting this to false sets the useAdapterCRDs mixer startup argument to false
       useAdapterCRDs: false
 
-  # Specify the pod anti-affinity that allows you to constrain which nodes
-  # your pod is eligible to be scheduled based on labels on pods that are
-  # already running on the node rather than based on labels on nodes.
-  # There are currently two types of anti-affinity:
-  #    "requiredDuringSchedulingIgnoredDuringExecution"
-  #    "preferredDuringSchedulingIgnoredDuringExecution"
-  # which denote “hard” vs. “soft” requirements, you can define your values
-  # in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
-  # correspondingly.
-  # For example:
-  # podAntiAffinityLabelSelector:
-  # - key: security
-  #   operator: In
-  #   values: S1,S2
-  #   topologyKey: "kubernetes.io/hostname"
-  # This pod anti-affinity rule says that the pod requires not to be scheduled
-  # onto a node if that node is already running a pod with label having key
-  # “security” and value “S1”.
-  podAntiAffinityLabelSelector: []
-  podAntiAffinityTermLabelSelector: []
+    nodeSelector: {}
+    tolerations: []
+
+    # Specify the pod anti-affinity that allows you to constrain which nodes
+    # your pod is eligible to be scheduled based on labels on pods that are
+    # already running on the node rather than based on labels on nodes.
+    # There are currently two types of anti-affinity:
+    #    "requiredDuringSchedulingIgnoredDuringExecution"
+    #    "preferredDuringSchedulingIgnoredDuringExecution"
+    # which denote “hard” vs. “soft” requirements, you can define your values
+    # in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+    # correspondingly.
+    # For example:
+    # podAntiAffinityLabelSelector:
+    # - key: security
+    #   operator: In
+    #   values: S1,S2
+    #   topologyKey: "kubernetes.io/hostname"
+    # This pod anti-affinity rule says that the pod requires not to be scheduled
+    # onto a node if that node is already running a pod with label having key
+    # “security” and value “S1”.
+    podAntiAffinityLabelSelector: []
+    podAntiAffinityTermLabelSelector: []

--- a/istio-telemetry/prometheus-operator/templates/_affinity.tpl
+++ b/istio-telemetry/prometheus-operator/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.prometheus.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -36,13 +43,13 @@
 {{- end }}
 
 {{- define "podAntiAffinity" }}
-{{- if or .Values.podAntiAffinityLabelSelector .Values.podAntiAffinityTermLabelSelector}}
+{{- if or .Values.prometheus.podAntiAffinityLabelSelector .Values.prometheus.podAntiAffinityTermLabelSelector}}
   podAntiAffinity:
-    {{- if .Values.podAntiAffinityLabelSelector }}
+    {{- if .Values.prometheus.podAntiAffinityLabelSelector }}
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.prometheus.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}
@@ -50,12 +57,12 @@
 {{- end }}
 
 {{- define "podAntiAffinityRequiredDuringScheduling" }}
-    {{- range $index, $item := .Values.podAntiAffinityLabelSelector }}
+    {{- range $index, $item := .Values.prometheus.podAntiAffinityLabelSelector }}
     - labelSelector:
         matchExpressions:
         - key: {{ $item.key }}
           operator: {{ $item.operator }}
-          {{- if $item.value }}
+          {{- if $item.values }}
           values:
           {{- $vals := split "," $item.values }}
           {{- range $i, $v := $vals }}
@@ -67,7 +74,7 @@
 {{- end }}
 
 {{- define "podAntiAffinityPreferredDuringScheduling" }}
-    {{- range $index, $item := .Values.podAntiAffinityTermLabelSelector }}
+    {{- range $index, $item := .Values.prometheus.podAntiAffinityTermLabelSelector }}
     - podAffinityTerm:
         labelSelector:
           matchExpressions:

--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -27,9 +27,6 @@ spec:
 {{- if .Values.prometheus.tolerations }}
   tolerations:
 {{ toYaml .Values.prometheus.tolerations | indent 2 }}
-{{- else if .Values.global.defaultTolerations }}
-  tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 2 }}
 {{- end }}
   podMetadata:
     labels:

--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -24,6 +24,13 @@ spec:
   affinity:
   {{- include "nodeaffinity" . | indent 2 }}
   {{- include "podAntiAffinity" . | indent 2 }}
+{{- if .Values.prometheus.tolerations }}
+  tolerations:
+{{ toYaml .Values.prometheus.tolerations | indent 2 }}
+{{- else if .Values.global.defaultTolerations }}
+  tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 2 }}
+{{- end }}
   podMetadata:
     labels:
       app: prometheus

--- a/istio-telemetry/prometheus-operator/values.yaml
+++ b/istio-telemetry/prometheus-operator/values.yaml
@@ -17,3 +17,27 @@ prometheus:
     nodePort:
       enabled: false
       port: 32090
+
+  nodeSelector: {}
+  tolerations: []
+
+  # Specify the pod anti-affinity that allows you to constrain which nodes
+  # your pod is eligible to be scheduled based on labels on pods that are
+  # already running on the node rather than based on labels on nodes.
+  # There are currently two types of anti-affinity:
+  #    "requiredDuringSchedulingIgnoredDuringExecution"
+  #    "preferredDuringSchedulingIgnoredDuringExecution"
+  # which denote “hard” vs. “soft” requirements, you can define your values
+  # in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+  # correspondingly.
+  # For example:
+  # podAntiAffinityLabelSelector:
+  # - key: security
+  #   operator: In
+  #   values: S1,S2
+  #   topologyKey: "kubernetes.io/hostname"
+  # This pod anti-affinity rule says that the pod requires not to be scheduled
+  # onto a node if that node is already running a pod with label having key
+  # “security” and value “S1”.
+  podAntiAffinityLabelSelector: []
+  podAntiAffinityTermLabelSelector: []

--- a/istio-telemetry/prometheus/templates/_affinity.tpl
+++ b/istio-telemetry/prometheus/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.prometheus.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.prometheus.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.prometheus.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/istio-telemetry/prometheus/templates/deployment.yaml
@@ -67,3 +67,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.prometheus.tolerations }}
+      tolerations:
+{{ toYaml .Values.prometheus.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/istio-telemetry/prometheus/templates/deployment.yaml
@@ -70,7 +70,4 @@ spec:
 {{- if .Values.prometheus.tolerations }}
       tolerations:
 {{ toYaml .Values.prometheus.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/istio-telemetry/prometheus/values.yaml
+++ b/istio-telemetry/prometheus/values.yaml
@@ -35,6 +35,9 @@ prometheus:
   security:
     enabled: true
 
+  nodeSelector: {}
+  tolerations: []
+
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.

--- a/istiocoredns/templates/_affinity.tpl
+++ b/istiocoredns/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.istiocoredns.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.istiocoredns.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.istiocoredns.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/istiocoredns/templates/deployment.yaml
+++ b/istiocoredns/templates/deployment.yaml
@@ -83,3 +83,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.istiocoredns.tolerations }}
+      tolerations:
+{{ toYaml .Values.istiocoredns.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/istiocoredns/templates/deployment.yaml
+++ b/istiocoredns/templates/deployment.yaml
@@ -86,7 +86,4 @@ spec:
 {{- if .Values.istiocoredns.tolerations }}
       tolerations:
 {{ toYaml .Values.istiocoredns.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/istiocoredns/values.yaml
+++ b/istiocoredns/values.yaml
@@ -10,6 +10,7 @@ istiocoredns:
   # The plugin listens for DNS requests from coredns server at 127.0.0.1:8053
   coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
   nodeSelector: {}
+  tolerations: []
 
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are

--- a/security/certmanager/templates/_affinity.tpl
+++ b/security/certmanager/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.certmanager.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.certmanager.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.certmanager.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/security/certmanager/templates/deployment.yaml
+++ b/security/certmanager/templates/deployment.yaml
@@ -59,7 +59,4 @@ spec:
 {{- if .Values.certmanager.tolerations }}
       tolerations:
 {{ toYaml .Values.certmanager.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/security/certmanager/templates/deployment.yaml
+++ b/security/certmanager/templates/deployment.yaml
@@ -56,3 +56,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.certmanager.tolerations }}
+      tolerations:
+{{ toYaml .Values.certmanager.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/security/certmanager/values.yaml
+++ b/security/certmanager/values.yaml
@@ -9,6 +9,7 @@ certmanager:
   tag: v0.6.2
   resources: {}
   nodeSelector: {}
+  tolerations: []
 
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are

--- a/security/citadel/templates/_affinity.tpl
+++ b/security/citadel/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.security.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.security.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.security.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -87,7 +87,4 @@ spec:
 {{- if .Values.security.tolerations }}
       tolerations:
 {{ toYaml .Values.security.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -84,3 +84,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.security.tolerations }}
+      tolerations:
+{{ toYaml .Values.security.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/security/citadel/values.yaml
+++ b/security/citadel/values.yaml
@@ -26,6 +26,9 @@ security:
 
     istio-galley-service-account.istio-config: istio-galley.istio-config.svc
 
+  nodeSelector: {}
+  tolerations: []
+
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are
   # already running on the node rather than based on labels on nodes.

--- a/security/nodeagent/templates/_affinity.tpl
+++ b/security/nodeagent/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.nodeagent.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}
@@ -42,7 +49,7 @@
     requiredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityRequiredDuringScheduling" . }}
     {{- end }}
-    {{- if or .Values.nodeagent.podAntiAffinityTermLabelSelector}}
+    {{- if .Values.nodeagent.podAntiAffinityTermLabelSelector }}
     preferredDuringSchedulingIgnoredDuringExecution:
     {{- include "podAntiAffinityPreferredDuringScheduling" . }}
     {{- end }}

--- a/security/nodeagent/templates/daemonset.yaml
+++ b/security/nodeagent/templates/daemonset.yaml
@@ -51,3 +51,10 @@ spec:
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+{{- if .Values.nodeagent.tolerations }}
+      tolerations:
+{{ toYaml .Values.nodeagent.tolerations | indent 6 }}
+{{- else if .Values.global.defaultTolerations }}
+      tolerations:
+{{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}

--- a/security/nodeagent/templates/daemonset.yaml
+++ b/security/nodeagent/templates/daemonset.yaml
@@ -54,7 +54,4 @@ spec:
 {{- if .Values.nodeagent.tolerations }}
       tolerations:
 {{ toYaml .Values.nodeagent.tolerations | indent 6 }}
-{{- else if .Values.global.defaultTolerations }}
-      tolerations:
-{{ toYaml .Values.global.defaultTolerations | indent 6 }}
 {{- end }}

--- a/security/nodeagent/values.yaml
+++ b/security/nodeagent/values.yaml
@@ -11,7 +11,9 @@ nodeagent:
     CA_ADDR: ""  
     # names of authentication provider's plugins.
     Plugins: ""
+
   nodeSelector: {}
+  tolerations: []
 
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are


### PR DESCRIPTION
- add nodeSelector
- add tolerations
- fix a few yaml format issues


For `nodeSelector` and `toleration`, define default values in global section to be applied to all deployments/daemonsets so that all pods can be scheduled to a particular nodes. Each component can overwrite these default values by adding its own block in the relevant section below and setting the desired values.