### PR TITLE
Exclude istioctl test

### DIFF
--- a/test/tests.mk
+++ b/test/tests.mk
@@ -77,7 +77,7 @@ run-mixer:
 		E2E_ARGS="${E2E_ARGS} --namespace=mixertest")
 
 # Test targets to run. Exclude tests that are broken for now
-INT_TARGETS = $(shell GOPATH=${GOPATH} go list ../istio/tests/integration/... | grep -v "/mixer/policy\|telemetry/tracing")
+INT_TARGETS = $(shell GOPATH=${GOPATH} go list ../istio/tests/integration/... | grep -v "/mixer/policy\|telemetry/tracing\|/istioctl")
 
 INT_FLAGS ?= \
 	--istio.test.hub ${HUB} \


### PR DESCRIPTION
We should be aware that this test is failing in a way that is a real issue and will affect users -- `istioctl version` is broken with the different namespaces.

However if we have a test that is always red we mask other issues so may be best to turn it off