### PR TITLE
verify statefulset for prometheus-operator test 

### DIFF
--- a/test/tests.mk
+++ b/test/tests.mk
@@ -133,4 +133,4 @@ run-mysql:
 run-prometheus-operator-config-test: PROM_OPTS="--set prometheus.createPrometheusResource=true"
 run-prometheus-operator-config-test: install-prometheus-operator install-prometheus-operator-config
 	if [ "$$(kubectl -n ${ISTIO_NS} get servicemonitors -o name | wc -l)" -ne "7" ]; then echo "Failure to find ServiceMonitor resouces!"; return 1; fi
-	kubectl -n ${ISTIO_NS} wait statefulset/prometheus-prometheus --for=condition=available --timeout=${WAIT_TIMEOUT}
+	until timeout ${WAIT_TIMEOUT}  kubectl -n ${ISTIO_NS} wait pod/prometheus-prometheus-0 --for=condition=Ready --timeout=${WAIT_TIMEOUT}

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -133,4 +133,6 @@ run-mysql:
 run-prometheus-operator-config-test: PROM_OPTS="--set prometheus.createPrometheusResource=true"
 run-prometheus-operator-config-test: install-prometheus-operator install-prometheus-operator-config
 	if [ "$$(kubectl -n ${ISTIO_NS} get servicemonitors -o name | wc -l)" -ne "7" ]; then echo "Failure to find ServiceMonitor resouces!"; return 1; fi
-	until timeout ${WAIT_TIMEOUT}  kubectl -n ${ISTIO_NS} wait pod/prometheus-prometheus-0 --for=condition=Ready --timeout=${WAIT_TIMEOUT}
+	# kubectl wait is problematic, as the pod may not exist before the command is issued.
+	until timeout ${WAIT_TIMEOUT} kubectl -n ${ISTIO_NS} get pod/prometheus-prometheus-0; do echo "Waiting for pods to be created..."; done
+	kubectl -n ${ISTIO_NS} wait pod/prometheus-prometheus-0 --for=condition=Ready --timeout=${WAIT_TIMEOUT}

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -133,4 +133,4 @@ run-mysql:
 run-prometheus-operator-config-test: PROM_OPTS="--set prometheus.createPrometheusResource=true"
 run-prometheus-operator-config-test: install-prometheus-operator install-prometheus-operator-config
 	if [ "$$(kubectl -n ${ISTIO_NS} get servicemonitors -o name | wc -l)" -ne "7" ]; then echo "Failure to find ServiceMonitor resouces!"; return 1; fi
-	kubectl -n ${ISTIO_NS} wait deploy/prometheus --for=condition=available --timeout=${WAIT_TIMEOUT}
+	kubectl -n ${ISTIO_NS} wait statefulset/prometheus-prometheus --for=condition=available --timeout=${WAIT_TIMEOUT}


### PR DESCRIPTION
See: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#prometheus
> For each Prometheus resource, the Operator deploys a properly configured StatefulSet in the same namespace. The Prometheus Pods are configured to mount a Secret called <prometheus-name> containing the configuration for Prometheus.

We should check the promesheus **statefulset**, instead of **deployment**, as prometheus-operator will create **statefulset** for each `Prometheus` resource, not **deployment**.