### PR TITLE
Remove prometheus metric_relabel_configs

### DIFF
--- a/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/istio-telemetry/prometheus/templates/configmap.yaml
@@ -52,38 +52,6 @@ data:
         action: replace
         target_label: pod_name
 
-      metric_relabel_configs:
-      # Exclude some of the envoy metrics that have massive cardinality
-      # This list may need to be pruned further moving forward, as informed
-      # by performance and scalability testing.
-      - source_labels: [ cluster_name ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ tcp_prefix ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ listener_address ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_listener_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tls.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tcp_downstream.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_http_(stats|admin).*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-        action: drop
-
     - job_name: 'istio-policy'
       kubernetes_sd_configs:
       - role: endpoints

--- a/kustomize/istio-telemetry/istio-grafana.yaml
+++ b/kustomize/istio-telemetry/istio-grafana.yaml
@@ -15862,38 +15862,6 @@ data:
         action: replace
         target_label: pod_name
 
-      metric_relabel_configs:
-      # Exclude some of the envoy metrics that have massive cardinality
-      # This list may need to be pruned further moving forward, as informed
-      # by performance and scalability testing.
-      - source_labels: [ cluster_name ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ tcp_prefix ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ listener_address ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_listener_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tls.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tcp_downstream.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_http_(stats|admin).*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-        action: drop
-
     - job_name: 'istio-policy'
       kubernetes_sd_configs:
       - role: endpoints

--- a/kustomize/istio-telemetry/istio-prometheus.yaml
+++ b/kustomize/istio-telemetry/istio-prometheus.yaml
@@ -51,38 +51,6 @@ data:
         action: replace
         target_label: pod_name
 
-      metric_relabel_configs:
-      # Exclude some of the envoy metrics that have massive cardinality
-      # This list may need to be pruned further moving forward, as informed
-      # by performance and scalability testing.
-      - source_labels: [ cluster_name ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ tcp_prefix ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ listener_address ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_listener_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tls.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tcp_downstream.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_http_(stats|admin).*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-        action: drop
-
     - job_name: 'istio-policy'
       kubernetes_sd_configs:
       - role: endpoints

--- a/test/demo/k8s.yaml
+++ b/test/demo/k8s.yaml
@@ -15862,38 +15862,6 @@ data:
         action: replace
         target_label: pod_name
 
-      metric_relabel_configs:
-      # Exclude some of the envoy metrics that have massive cardinality
-      # This list may need to be pruned further moving forward, as informed
-      # by performance and scalability testing.
-      - source_labels: [ cluster_name ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ tcp_prefix ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ listener_address ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_listener_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tls.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tcp_downstream.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_http_(stats|admin).*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-        action: drop
-
     - job_name: 'istio-policy'
       kubernetes_sd_configs:
       - role: endpoints


### PR DESCRIPTION
We control the metrics that are emitted at the proxy.
This configuration is no longer needed.