### PR TITLE
Forward-port a missing feature from the old installer

### DIFF
--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -88,6 +88,9 @@ data:
     - address: istio-galley:9901
     {{- end }}
     {{- end }}
+
+    localityLbSetting:
+{{ toYaml .Values.global.localityLbSetting | indent 6 }}
     #
     defaultConfig:
       #


### PR DESCRIPTION
Adds support of configuring 'locality-aware load balancing' via the `values.yaml`.