### PR TITLE
fix values structure for istio-cni.

### DIFF
--- a/istio-cni/values_gke.yaml
+++ b/istio-cni/values_gke.yaml
@@ -1,18 +1,19 @@
-hub: docker.io/tiswanso
-tag: v0.1-dev
-pullPolicy: Always
+cni:
+  hub: docker.io/tiswanso
+  tag: v0.1-dev
+  pullPolicy: Always
 
-logLevel: info
+  logLevel: info
 
-# Configuration file to insert istio-cni plugin configuration
-# by default this will be the first file found in the cni-conf-dir
-# Example
-# cniConfFileName: 10-calico.conflist
+  # Configuration file to insert istio-cni plugin configuration
+  # by default this will be the first file found in the cni-conf-dir
+  # Example
+  # cniConfFileName: 10-calico.conflist
 
-# CNI bin and conf dir override settings
-# defaults:
-cniBinDir: /home/kubernetes/bin
-cniConfDir: /etc/cni/net.d
+  # CNI bin and conf dir override settings
+  # defaults:
+  cniBinDir: /home/kubernetes/bin
+  cniConfDir: /etc/cni/net.d
 
-excludeNamespaces:
-  - istio-system
+  excludeNamespaces:
+    - istio-system


### PR DESCRIPTION
Followup PR for https://github.com/istio/installer/pull/195, all values for istio-cni are supposed to be under `cni` parent.