### PR TITLE
Add ability to send annotations as env vars automagically

### DIFF
--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -193,6 +193,11 @@ spec:
             value: {{ $val }}
           {{- end }}
           {{ end }}
+{{- if $gateway.podAnnotations }}
+          - name: "ISTIO_METAJSON_ANNOTATIONS"
+            value: |
+{{ toJson $gateway.podAnnotations | indent 16}}
+{{ end }}
           volumeMounts:
           {{ if .Values.global.sds.enabled }}
           - name: sdsudspath

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -217,6 +217,11 @@ spec:
             value: {{ $val }}
           {{- end }}
           {{- end }}
+{{- if $gateway.podAnnotations }}
+          - name: "ISTIO_METAJSON_ANNOTATIONS"
+            value: |
+{{ toJson $gateway.podAnnotations | indent 16}}
+{{ end }}
           volumeMounts:
           {{ if .Values.global.sds.enabled }}
           - name: sdsudspath


### PR DESCRIPTION
for a gateway pod-annotations must also be set in the env.