### PR TITLE
Change run-test-on-base-installation to use integrationRemoteIsolated…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
           path: /go/out/tests
 
   run-test-on-base-installation:
-    <<: *integrationRemoteOneNamespace
+    <<: *integrationRemoteIsolatedNamespaces
 
     # Can run multiple images, first is primary, all use localhost
     steps:


### PR DESCRIPTION
Circle CI tests were not running with the original PR #143. Unfortunately, this PR was merged automatically.