### PR TITLE
backport to 1.2: fix configNamespace for telemetry (#201)

### DIFF
--- a/kustomize/istio-telemetry/mixer-telemetry.yaml
+++ b/kustomize/istio-telemetry/mixer-telemetry.yaml
@@ -486,7 +486,7 @@ spec:
           - unix:///sock/mixer.socket
           - --log_output_level=default:info
           - --configStoreURL=mcp://localhost:15019
-          - --configDefaultNamespace=istio-control
+          - --configDefaultNamespace=istio-telemetry
           - --useAdapterCRDs=false
           - --useTemplateCRDs=false
           - --trace_zipkin_url=http://zipkin.istio-telemetry:9411/api/v1/spans


### PR DESCRIPTION
Was merged before auto backport was merged