### PR TITLE
Proposal to increase default replica counts when default PDB is in use

### DIFF
--- a/gateways/istio-egress/templates/autoscale.yaml
+++ b/gateways/istio-egress/templates/autoscale.yaml
@@ -10,7 +10,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   maxReplicas: {{ $gateway.autoscaleMax }}
+{{- if $gateway.autoscaleMin }}
   minReplicas: {{ $gateway.autoscaleMin }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  minReplicas: 2
+{{- else }}
+  minReplicas: 1
+{{- end }}
+{{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -13,7 +13,11 @@ spec:
 {{- if $gateway.replicaCount }}
   replicas: {{ $gateway.replicaCount }}
 {{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
   replicas: 1
+{{- end }}
 {{- end }}
 {{- end }}
   selector:

--- a/gateways/istio-egress/values.yaml
+++ b/gateways/istio-egress/values.yaml
@@ -25,9 +25,9 @@ gateways:
 
 
     # Scalability tunning
-    # replicaCount: 1
+    # replicaCount: 2
     autoscaleEnabled: true
-    autoscaleMin: 1
+    # autoscaleMin: 2
     autoscaleMax: 5
     resources:
       requests:

--- a/gateways/istio-ingress/templates/autoscale.yaml
+++ b/gateways/istio-ingress/templates/autoscale.yaml
@@ -10,7 +10,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   maxReplicas: {{ $gateway.autoscaleMax }}
+{{- if $gateway.autoscaleMin }}
   minReplicas: {{ $gateway.autoscaleMin }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  minReplicas: 2
+{{- else }}
+  minReplicas: 1
+{{- end }}
+{{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -13,7 +13,11 @@ spec:
 {{- if $gateway.replicaCount }}
   replicas: {{ $gateway.replicaCount }}
 {{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
   replicas: 1
+{{- end }}
 {{- end }}
 {{- end }}
   selector:

--- a/gateways/istio-ingress/values.yaml
+++ b/gateways/istio-ingress/values.yaml
@@ -38,9 +38,9 @@ gateways:
       name: tls
 
     # Scalability tunning
-    # replicaCount: 1
+    # replicaCount: 2
     autoscaleEnabled: true
-    autoscaleMin: 1
+    # autoscaleMin: 2
     autoscaleMax: 5
 
     cpu:

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -8,7 +8,15 @@ metadata:
     release: {{ .Release.Name }}
     istio: sidecar-injector
 spec:
+{{- if .Values.sidecarInjectorWebhook.replicaCount }}
   replicas: {{ .Values.sidecarInjectorWebhook.replicaCount }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
+  replicas: 1
+{{- end }}
+{{- end }}
   selector:
     matchLabels:
       istio: sidecar-injector

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -2,7 +2,7 @@ sidecarInjectorWebhook:
   # sidecar-injector webhook configuration.
   # If down, new pods will fail to start or restart for a short time, but they will
   # retry.
-  replicaCount: 1
+  # replicaCount: 2
 
   image: sidecar_injector
 

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -8,7 +8,15 @@ metadata:
     istio: galley
     release: {{ .Release.Name }}
 spec:
+{{- if .Values.galley.replicaCount }}
   replicas: {{ .Values.galley.replicaCount }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
+  replicas: 1
+{{- end }}
+{{- end }}
   selector:
     matchLabels:
       app: galley

--- a/istio-control/istio-config/values.yaml
+++ b/istio-control/istio-config/values.yaml
@@ -1,6 +1,6 @@
 galley:
   image: galley
-  replicaCount: 1
+  # replicaCount: 2
 
   resources:
     requests:

--- a/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/istio-control/istio-discovery/templates/autoscale.yaml
@@ -9,7 +9,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}
+{{- if .Values.pilot.autoscaleMin }}
   minReplicas: {{ .Values.pilot.autoscaleMin }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  minReplicas: 2
+{{- else }}
+  minReplicas: 1
+{{- end }}
+{{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -18,7 +18,11 @@ spec:
 {{- if .Values.pilot.replicaCount }}
   replicas: {{ .Values.pilot.replicaCount }}
 {{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
   replicas: 1
+{{- end }}
 {{- end }}
 {{- end }}
   strategy:

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -3,9 +3,9 @@
 ## Discovery Settings
 pilot:
   autoscaleEnabled: true
-  autoscaleMin: 1
+  # autoscaleMin: 2
   autoscaleMax: 5
-  replicaCount: 1
+  # replicaCount: 2
 
   # Can be a full hub/image:tag
   image: pilot

--- a/istio-policy/templates/autoscale.yaml
+++ b/istio-policy/templates/autoscale.yaml
@@ -9,7 +9,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
     maxReplicas: {{ .Values.mixer.policy.autoscaleMax }}
+{{- if .Values.mixer.policy.autoscaleMin }}
     minReplicas: {{ .Values.mixer.policy.autoscaleMin }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+    minReplicas: 2
+{{- else }}
+    minReplicas: 1
+{{- end }}
+{{- end }}
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -8,7 +8,15 @@ metadata:
     istio: mixer
     release: {{ .Release.Name }}
 spec:
+{{- if .Values.mixer.policy.replicaCount }}
   replicas: {{ .Values.mixer.policy.replicaCount }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
+  replicas: 1
+{{- end }}
+{{- end }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/istio-policy/values.yaml
+++ b/istio-policy/values.yaml
@@ -2,9 +2,9 @@ mixer:
   policy:
     image: mixer
 
-    replicaCount: 1
+    # replicaCount: 2
     autoscaleEnabled: true
-    autoscaleMin: 1
+    # autoscaleMin: 2
     autoscaleMax: 5
     cpu:
       targetAverageUtilization: 80

--- a/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
@@ -9,7 +9,15 @@ metadata:
     app: istio-telemetry
 spec:
     maxReplicas: {{ .Values.mixer.telemetry.autoscaleMax }}
+{{- if .Values.mixer.telemetry.autoscaleMin }}
     minReplicas: {{ .Values.mixer.telemetry.autoscaleMin }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+    minReplicas: 2
+{{- else }}
+    minReplicas: 1
+{{- end }}
+{{- end }}
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -8,7 +8,15 @@ metadata:
     istio: mixer
     release: {{ .Release.Name }}
 spec:
+{{- if .Values.mixer.telemetry.replicaCount }}
   replicas: {{ .Values.mixer.telemetry.replicaCount }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
+  replicas: 1
+{{- end }}
+{{- end }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -2,9 +2,9 @@ mixer:
   telemetry:
     image: mixer
     enabled: true
-    replicaCount: 1
+    # replicaCount: 2
     autoscaleEnabled: true
-    autoscaleMin: 1
+    # autoscaleMin: 2
     autoscaleMax: 5
     cpu:
       targetAverageUtilization: 80

--- a/security/certmanager/templates/deployment.yaml
+++ b/security/certmanager/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: certmanager
     release: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.certmanager.replicaCount }}
   selector:
     matchLabels:
       app: certmanager

--- a/security/certmanager/templates/deployment.yaml
+++ b/security/certmanager/templates/deployment.yaml
@@ -7,7 +7,15 @@ metadata:
     app: certmanager
     release: {{ .Release.Name }}
 spec:
+{{- if .Values.certmanager.replicaCount }}
   replicas: {{ .Values.certmanager.replicaCount }}
+{{- else }}
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+  replicas: 2
+{{- else }}
+  replicas: 1
+{{- end }}
+{{- end }}
   selector:
     matchLabels:
       app: certmanager

--- a/security/certmanager/values.yaml
+++ b/security/certmanager/values.yaml
@@ -5,6 +5,7 @@ certmanager:
   # gateway must be updated by adding 'secretVolumes'. After the gateway
   # restart, DestinationRules can be created using the ACME-signed certificates.
   enabled: false
+  replicaCount: 1
   hub: quay.io/jetstack
   tag: v0.6.2
   resources: {}

--- a/security/certmanager/values.yaml
+++ b/security/certmanager/values.yaml
@@ -5,7 +5,7 @@ certmanager:
   # gateway must be updated by adding 'secretVolumes'. After the gateway
   # restart, DestinationRules can be created using the ACME-signed certificates.
   enabled: false
-  replicaCount: 1
+  # replicaCount: 2
   hub: quay.io/jetstack
   tag: v0.6.2
   resources: {}


### PR DESCRIPTION
This is a proposal for "fixing": https://github.com/istio/istio/issues/12602

I based the logic on what i found in `gateways/istio-egress`.

This is just a proposal, another option could be to set `defaultPodDisruptionBudget.enabled = false` in `global.yaml` or update documentation to the effect that default installs must be scaled before node maintenance is possible.