### PR TITLE
fix ingress deployment name

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -82,7 +82,7 @@ function install_ingress() {
 
     kubectl patch deployment -n istio-ingress ingressgateway --patch '{"spec": {"strategy": {"rollingUpdate": {"maxSurge": 1,"maxUnavailable": 0},"type": "RollingUpdate"}}}'
     kubectl rollout status  deployment istio-pilot -n istio-ingress --timeout=$WAIT_TIMEOUT
-    kubectl rollout status  deployment ingressgateway -n istio-ingress --timeout=$WAIT_TIMEOUT
+    kubectl rollout status  deployment istio-ingressgateway -n istio-ingress --timeout=$WAIT_TIMEOUT
 }
 
 # Install grafana, mixer and prometheus into namespace istio-telemetry


### PR DESCRIPTION
match [name](https://github.com/istio/installer/blob/master/gateways/istio-ingress/templates/deployment.yaml#L5)
```
+ kubectl rollout status deployment ingressgateway -n istio-ingress --timeout=5m
Error from server (NotFound): deployments.extensions "ingressgateway" not found
```