### PR TITLE
Revert "remove pdb for cert-manager."

### DIFF
--- a/security/certmanager/templates/poddisruptionbudget.yaml
+++ b/security/certmanager/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: certmanager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: certmanager
+    release: {{ .Release.Name }}
+    {{- if .Values.certmanager.podLabels }}
+{{ toYaml .Values.certmanager.podLabels | indent 4 }}
+    {{- end }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: certmanager
+      release: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
Since the replicas of cert-manager is configurable  after https://github.com/istio/installer/pull/210, we need to reverts istio/installer#220 to add back PDB for cert-manager.