### PR TITLE
Make sidecar injector clusterrole more restrictive by specifying resourcenames

### DIFF
--- a/istio-control/istio-autoinject/templates/clusterrole.yaml
+++ b/istio-control/istio-autoinject/templates/clusterrole.yaml
@@ -9,7 +9,9 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
+  resourceNames: ["istio-sidecar-injector"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
+  resourceNames: [{{ print "\"istio-sidecar-injector-" .Release.Namespace "\"" }}]
   verbs: ["get", "list", "watch", "patch"]


### PR DESCRIPTION
**NOTE** Creating a duplicate PR to check cla

@sdake 

Tested this manually for-

1. go templating
2. functionality by verifying in our test cluster that auto injection of sidecar works with the updated role 