### PR TITLE
Automatically create PRs to update kustomize templates

### DIFF
--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -123,9 +123,9 @@ jobs:
         run:
           path: /bin/sh
           args:
-          - -ec
+          - -ecu
           - |
-            git config --global credential.helper 'store
+            git config --global credential.helper store
             echo "https://ConcourseWdf:${CONCOURSE_WDF_PASSWORD}@github.com" > ~/.git-credentials
             set -x
             cd istio-installer
@@ -138,13 +138,14 @@ jobs:
               git commit -a -m "Update kustomize templates."
               git remote add c0d1ngm0nk3y "https://github.com/c0d1ngm0nk3y/istio-installer.git"
               git push -u c0d1ngm0nk3y $BRANCH_NAME:$BRANCH_NAME
-              curl -X POST -H 'Content-type: application/json' \
+              set +x
+              HTTP_CODE=$(curl -X POST -H 'Content-type: application/json' \
                 -d "{  \"title\": \"Update kustomize templates\", \"body\": \"This PR is created automatically!\", \"head\": \"c0d1ngm0nk3y:$BRANCH_NAME\", \"base\": \"master\" } " \
                 -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
                 -H 'Content-Type: application/json' \
                 -H 'Accept: application/vnd.github.v3+json' \
                 -w %{http_code} -o /dev/null -s \
-                https://api.github.com/repos/istio/installer/pulls
+                https://api.github.com/repos/istio/installer/pulls)
               if [ "$HTTP_CODE" -ne 201 ]; then
                 echo "No pull request created"
                 exit 1

--- a/.concourse/concourse.yaml
+++ b/.concourse/concourse.yaml
@@ -103,3 +103,50 @@ jobs:
             echo "$KUBECONFIG" > /tmp/kubeconfig.yaml
             export KUBECONFIG=/tmp/kubeconfig.yaml
             ISTIO_CONTROL=istio-system INGRESS_NS=istio-system istio-installer/bin/test.sh --skip-cleanup src/github.com/istio/istio/
+
+  - name: update-kustomize-templates
+    plan:
+    - get: istio-installer
+      trigger: true
+    - task: update-kustomize-templates
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: gcr.io/peripli/istio-base
+        params:
+          GITHUB_ACCESS_TOKEN: ((GITHUB_ACCESS_TOKEN))
+          CONCOURSE_WDF_PASSWORD: ((CONCOURSE_WDF_PASSWORD))
+        inputs:
+          - name: istio-installer
+        run:
+          path: /bin/sh
+          args:
+          - -ec
+          - |
+            git config --global credential.helper 'store
+            echo "https://ConcourseWdf:${CONCOURSE_WDF_PASSWORD}@github.com" > ~/.git-credentials
+            set -x
+            cd istio-installer
+            make run-build
+            if ! git diff --exit-code >/dev/null ; then
+              BRANCH_NAME="update-kustomize-$(git rev-parse HEAD)"
+              git config --global user.email "public@holger-oehm.de"
+              git config --global user.name "ConcourseWdf"
+              git checkout -b "$BRANCH_NAME"
+              git commit -a -m "Update kustomize templates."
+              git remote add c0d1ngm0nk3y "https://github.com/c0d1ngm0nk3y/istio-installer.git"
+              git push -u c0d1ngm0nk3y $BRANCH_NAME:$BRANCH_NAME
+              curl -X POST -H 'Content-type: application/json' \
+                -d "{  \"title\": \"Update kustomize templates\", \"body\": \"This PR is created automatically!\", \"head\": \"c0d1ngm0nk3y:$BRANCH_NAME\", \"base\": \"master\" } " \
+                -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
+                -H 'Content-Type: application/json' \
+                -H 'Accept: application/vnd.github.v3+json' \
+                -w %{http_code} -o /dev/null -s \
+                https://api.github.com/repos/istio/installer/pulls
+              if [ "$HTTP_CODE" -ne 201 ]; then
+                echo "No pull request created"
+                exit 1
+              fi
+            fi


### PR DESCRIPTION
In order to keep `kubectl apply -k` in sync with installing istio via iop/helm, we have created a pipeline job that automatically builds the installer and creates a PR to istio/installer with the updated kustomize templates.

An exemplary PR is https://github.com/istio/installer/pull/235.