### PR TITLE
Remove presubmit label

### DIFF
--- a/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
@@ -108,6 +108,11 @@ webhooks:
         - quotas
         - reportnothings
         - tracespans
+        - adapters
+        - handlers
+        - instances
+        - templates
+        - zipkins
     failurePolicy: Fail
     sideEffects: None
 {{- end }}

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -118,7 +118,7 @@ run-test.integration.kube.presubmit:
 
 	set -o pipefail; \
 	cd ${GOPATH}/src/istio.io/istio; \
-	${GO} test -v ${INT_TARGETS} --istio.test.select +customsetup ${INT_FLAGS} 2>&1 | tee ${GOPATH}/out/logs/$@.log
+	${GO} test -v ${INT_TARGETS} --istio.test.select -customsetup,-flaky ${INT_FLAGS} 2>&1 | tee ${GOPATH}/out/logs/$@.log
 
 run-stability:
 	 ISTIO_ENV=${ISTIO_CONTROL_NS} bin/iop test stability ${GOPATH}/src/istio.io/tools/perf/stability/allconfig ${IOP_OPTS}

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -118,7 +118,7 @@ run-test.integration.kube.presubmit:
 
 	set -o pipefail; \
 	cd ${GOPATH}/src/istio.io/istio; \
-	${GO} test -v ${INT_TARGETS} --istio.test.select -customsetup,+presubmit ${INT_FLAGS} 2>&1 | tee ${GOPATH}/out/logs/$@.log
+	${GO} test -v ${INT_TARGETS} --istio.test.select +customsetup ${INT_FLAGS} 2>&1 | tee ${GOPATH}/out/logs/$@.log
 
 run-stability:
 	 ISTIO_ENV=${ISTIO_CONTROL_NS} bin/iop test stability ${GOPATH}/src/istio.io/tools/perf/stability/allconfig ${IOP_OPTS}


### PR DESCRIPTION
The installer code changes cannot pass the ci due to https://github.com/istio/istio/pull/14680. remove the `presubmit` in this repo accordingly.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>