### PR TITLE
Use strict version for zipkin

### DIFF
--- a/istio-telemetry/tracing/values.yaml
+++ b/istio-telemetry/tracing/values.yaml
@@ -36,7 +36,7 @@ tracing:
 
   zipkin:
     hub: docker.io/openzipkin
-    tag: 2
+    tag: 2.14.2
     probeStartupDelay: 200
     queryPort: 9411
     resources:


### PR DESCRIPTION
There has some problems I think
1. The image is from docker hub.
![image](https://user-images.githubusercontent.com/7711311/59659634-2ec36980-91d9-11e9-8005-aa81755f5470.png)
if we use the version `2`,  it may lead our tested version is not same as released version. for example: when we did test for 2.14.1 and client may use 2.14.2 for their environment.

2. we have another PR to ensure the `imagePullPolicy` is `IfNotPresent`. after that, the latest or our desired image cannot be applied to client's environment if there is an old version `2` exists.

FYI @morvencao 

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>