### PR TITLE
Validate new mixer CRDs

### DIFF
--- a/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
@@ -108,6 +108,11 @@ webhooks:
         - quotas
         - reportnothings
         - tracespans
+        - adapters
+        - handlers
+        - instances
+        - templates
+        - zipkins
     failurePolicy: Fail
     sideEffects: None
 {{- end }}


### PR DESCRIPTION
Many PRs cannot pass the ci test, the reason is we introduced some new validation files for new mixer CRDs, we need add them back in installer repo

```
--- FAIL: TestValidation/config-v1alpha2-instance-invalid.yaml (0.52s)
    	validation_test.go:112: got unexpected success for invalid config
    --- PASS: TestValidation/rbac-v1alpha1-AuthorizationPolicy-invalid.yaml (0.57s)
    --- PASS: TestValidation/config-v1alpha2-HTTPAPISpec-invalid.yaml (0.56s)
    --- FAIL: TestValidation/config-v1alpha2-adapter-invalid.yaml (1.04s)
    	validation_test.go:112: got unexpected success for invalid config
    --- PASS: TestValidation/config-v1alpha2-handler-valid.yaml (1.16s)
    --- PASS: TestValidation/networking-v1alpha3-Sidecar-invalid.yaml (0.51s)
    --- PASS: TestValidation/networking-v1alpha3-VirtualService-invalid.yaml (0.70s)
    --- PASS: TestValidation/authentication-v1alpha1-Policy-invalid.yaml (0.57s)
    --- PASS: TestValidation/config-v1alpha2-attributemanifest-valid.yaml (0.93s)
    --- PASS: TestValidation/rbac-v1alpha1-ClusterRbacConfig-valid.yaml (1.09s)
    --- PASS: TestValidation/rbac-v1alpha1-RBacConfig-valid.yaml (0.79s)
    --- PASS: TestValidation/rbac-v1alpha1-ServiceRoleBinding-invalid.yaml (0.70s)
    --- FAIL: TestValidation/config-v1alpha2-template-invalid.yaml (0.84s)
    	validation_test.go:112: got unexpected success for invalid config
    --- PASS: TestValidation/networking-v1alpha3-DestinationRule-valid.yaml (0.92s)
    --- PASS: TestValidation/rbac-v1alpha1-ServiceRole-invalid.yaml (1.15s)
    --- PASS: TestValidation/authentication-v1alpha1-Policy-valid.yaml (0.96s)
    --- PASS: TestValidation/config-v1alpha2-QuotaSpec-invalid.yaml (0.87s)
    --- PASS: TestValidation/networking-v1alpha3-Gateway-valid.yaml (1.06s)
    --- PASS: TestValidation/networking-v1alpha3-ServiceEntry-valid.yaml (0.66s)
    --- PASS: TestValidation/networking-v1alpha3-Sidecar-valid.yaml (0.85s)
    --- PASS: TestValidation/rbac-v1alpha1-AuthorizationPolicy-valid.yaml (0.91s)
    --- PASS: TestValidation/rbac-v1alpha1-RBacConfig-invalid.yaml (1.23s)
    --- PASS: TestValidation/rbac-v1alpha1-ServiceRoleBinding-valid.yaml (0.68s)
    --- PASS: TestValidation/config-v1alpha2-attributemanifest-invalid.yaml (0.71s)
    --- PASS: TestValidation/networking-v1alpha3-EnvoyFilter-valid.yaml (0.89s)
    --- PASS: TestValidation/config-v1alpha2-instance-valid.yaml (0.73s)
    --- PASS: TestValidation/config-v1alpha2-rule-valid.yaml (0.99s)
    --- PASS: TestValidation/config-v1alpha2-template-valid.yaml (1.32s)
    --- PASS: TestValidation/networking-v1alpha3-EnvoyFilter-invalid.yaml (0.77s)
    --- PASS: TestValidation/networking-v1alpha3-VirtualService-valid.yaml (0.63s)
    --- PASS: TestValidation/config-v1alpha2-HTTPAPISpec-valid.yaml (0.52s)
    --- PASS: TestValidation/config-v1alpha2-adapter-valid.yaml (0.96s)
    --- PASS: TestValidation/config-v1alpha2-QuotaSpecBinding-invalid.yaml (1.32s)
    --- PASS: TestValidation/config-v1alpha2-QuotaSpecBinding-valid.yaml (1.09s)
    --- PASS: TestValidation/config-v1alpha2-rule-invalid.yaml (0.75s)
    --- PASS: TestValidation/networking-v1alpha3-DestinationRule-invalid.yaml (0.53s)
    --- PASS: TestValidation/networking-v1alpha3-ServiceEntry-invalid.yaml (1.24s)
    --- PASS: TestValidation/authentication-v1alpha1-MeshPolicy-invalid.yaml (0.70s)
    --- PASS: TestValidation/config-v1alpha2-HTTPAPISpecBinding-valid.yaml (1.04s)
    --- PASS: TestValidation/config-v1alpha2-QuotaSpec-valid.yaml (0.92s)
    --- FAIL: TestValidation/config-v1alpha2-handler-invalid.yaml (0.66s)
    	validation_test.go:112: got unexpected success for invalid config
    --- PASS: TestValidation/networking-v1alpha3-Gateway-invalid.yaml (0.90s)
    --- PASS: TestValidation/rbac-v1alpha1-ClusterRbacConfig-invalid.yaml (0.63s)
    --- PASS: TestValidation/rbac-v1alpha1-ServiceRole-valid.yaml (0.83s)
    --- PASS: TestValidation/authentication-v1alpha1-MeshPolicy-valid.yaml (0.90s)
    --- PASS: TestValidation/config-v1alpha2-HTTPAPISpecBinding-invalid.yaml (0.67s)
```

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>