### PR TITLE
Sidecar auto-inject with istio-env label

### DIFF
--- a/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
+++ b/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
@@ -36,7 +36,7 @@ webhooks:
         values:
         - disabled
       - key: istio-env
-        operator: DoesNotExist
+        operator: Exists
 {{- else }}
       matchLabels:
         istio-env: {{ .Release.Namespace }}


### PR DESCRIPTION
Here is the description in readme
> Only one auto-injector environment should have enableNamespacesByDefault=true, which will apply that environment to any namespace without an explicit istio-env label.

I think we should use the same label for injecting all namespaces or selected namespaces. before my change,
```
istio-bookinfo-1-32720    Active   116m   istio-env=istio-control,istio-injection=enabled,istio-testing=istio-test
```
istio-bookinfo-1-32720 cannot have sidecar injected if `enableNamespacesByDefault` is true.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>