### PR TITLE
Update the clusterrole for citadel

### DIFF
--- a/security/citadel/templates/clusterrole.yaml
+++ b/security/citadel/templates/clusterrole.yaml
@@ -7,11 +7,14 @@ metadata:
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "update"]
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts"]
+  resources: ["serviceaccounts", "services"]
   verbs: ["get", "watch", "list"]
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "watch", "list"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]


### PR DESCRIPTION
cannot create configmap `istio-citadel` without proper permission.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>