### PR TITLE
use istio-system for istioNamespace and systemNamespace

### DIFF
--- a/test/tests.mk
+++ b/test/tests.mk
@@ -88,8 +88,8 @@ INT_FLAGS ?= \
 	--istio.test.ci \
 	--istio.test.nocleanup \
 	--istio.test.kube.deploy=false \
-	--istio.test.kube.systemNamespace ${ISTIO_CONTROL_NS} \
-	--istio.test.kube.istioNamespace ${ISTIO_CONTROL_NS} \
+	--istio.test.kube.systemNamespace ${ISTIO_SYSTEM_NS} \
+	--istio.test.kube.istioNamespace ${ISTIO_SYSTEM_NS} \
 	--istio.test.kube.configNamespace ${ISTIO_CONTROL_NS} \
 	--istio.test.kube.telemetryNamespace ${ISTIO_TELEMETRY_NS} \
 	--istio.test.kube.policyNamespace ${ISTIO_POLICY_NS} \


### PR DESCRIPTION
fix the issue about
```
--- FAIL: TestCitadelBootstrapKubernetes (10.67s)
bootstrap_writesecret_test.go:65: Failed to retrieve Citadel CA-root secret.
```
for the new installer, the citadel is in `istio-system` ns instead of `istio-control`

Signed-off-by: clyang82 <clyang@cn.ibm.com>