### PR TITLE
make all images configurable

### DIFF
--- a/istio-cni/templates/daemonset.yaml
+++ b/istio-cni/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         # This container installs the Istio CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .Values.cni.hub }}/install-cni:{{ .Values.cni.tag }}
+          image: {{ .Values.cni.hub }}/{{ .values.cni.image | default "install-cni" }}:{{ .Values.cni.tag }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
           command: ["/install-cni.sh"]
           env:

--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 spec:
-  image: "{{ .Values.prometheus.hub }}/prometheus:{{ .Values.prometheus.tag }}"
+  image: "{{ .Values.prometheus.hub }}/{{ .Values.prometheus.image | default "prometheus" }}:{{ .Values.prometheus.tag }}"
   version: {{ .Values.prometheus.tag }}
   retention: {{ .Values.prometheus.retention }}
   scrapeInterval: {{ .Values.prometheus.scrapeInterval }}


### PR DESCRIPTION
Some image names have been hardcoded in helm templates.
This PR makes all the image names configurable via helm values.

I have defaulted them to original values in their respective values.yaml to ensure backward compatibility.

why?
In my use-case, all images have to come from an internal image repository and it has strict naming conventions. This change allows changing image names without having to maintain a fork and change image names in the source.