### PR TITLE
Turn on namespaces by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,8 @@ jobs:
       - run:
           command: make sync
       - run:
-          command: make kind-run TARGET="install-base ENABLE_NAMESPACES_BY_DEFAULT=false"
+          # todo: set ENABLE_NAMESPACES_BY_DEFAULT=false once integration tests can support it
+          command: make kind-run TARGET="install-base"
       - run:
           command: make docker-run-test TEST_TARGET="run-minimal-test"
       - run:


### PR DESCRIPTION
Currently the test framework can either always set the namespace label
or never set it. We need to make it smarter then we can turn this back
on.