### PR TITLE
Added --log_as_json container arg to all istio components

### DIFF
--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -88,6 +88,9 @@ spec:
         {{- if .Values.global.logging.level }}
           - --log_output_level={{ .Values.global.logging.level }}
         {{- end}}
+        {{- if .Values.global.logAsJson }}
+          - --log_as_json
+        {{- end }}
           - --drainDuration
           - '45s' #drainDuration
           - --parentShutdownDuration

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -111,6 +111,9 @@ spec:
         {{- if .Values.global.logging.level }}
           - --log_output_level={{ .Values.global.logging.level }}
         {{- end}}
+        {{- if .Values.global.logAsJson }}
+          - --log_as_json
+        {{- end }}
           - --drainDuration
           - '45s' #drainDuration
           - --parentShutdownDuration

--- a/global.yaml
+++ b/global.yaml
@@ -23,7 +23,7 @@ global:
 
   # Telemetry namespace, including tracing.
   telemetryNamespace: istio-telemetry
- 
+
   prometheusNamespace: istio-telemetry
 
   policyNamespace: istio-policy
@@ -45,6 +45,9 @@ global:
   # If empty, default scope and level will be used as configured in code
   logging:
     level: "default:info"
+
+  # To output all istio components logs in json format by adding --log_as_json argument to each container argument
+  logAsJson: false
 
   k8sIngress:
     enabled: false
@@ -160,7 +163,7 @@ global:
     # available to scrape via the Envoy admin port at either /stats or /stats/prometheus.
     #
     # See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto
-    # for details about Envoy's Metrics Service API. 
+    # for details about Envoy's Metrics Service API.
     #
     # Disabled by default.
     envoyMetricsService:
@@ -248,9 +251,9 @@ global:
   # If not set, controller watches all namespaces
   oneNamespace: false
 
-  # Default node selector to be applied to all deployments so that all pods can be 
-  # constrained to run a particular nodes. Each component can overwrite these default 
-  # values by adding its node selector block in the relevant section below and setting 
+  # Default node selector to be applied to all deployments so that all pods can be
+  # constrained to run a particular nodes. Each component can overwrite these default
+  # values by adding its node selector block in the relevant section below and setting
   # the desired values.
   defaultNodeSelector: {}
 
@@ -327,7 +330,7 @@ global:
   #   services or ServiceEntries for the destination port
   # REGISTRY_ONLY - restrict outbound traffic to services defined in the service registry as well
   #   as those defined through ServiceEntries
-  # ALLOW_ANY is the default in 1.1.  This means each pod will be able to make outbound requests 
+  # ALLOW_ANY is the default in 1.1.  This means each pod will be able to make outbound requests
   # to services outside of the mesh without any ServiceEntry.
   # REGISTRY_ONLY was the default in 1.0.  If this behavior is desired, set the value below to REGISTRY_ONLY.
   outboundTrafficPolicy:
@@ -342,7 +345,7 @@ global:
   # rules should be exported to. Currently only one value can be provided in this list. This value
   # should be one of the following two options:
   # * implies these objects are visible to all namespaces, enabling any sidecar to talk to any other sidecar.
-  # . implies these objects are visible to only to sidecars in the same namespace, or if imported as a Sidecar.egress.host  
+  # . implies these objects are visible to only to sidecars in the same namespace, or if imported as a Sidecar.egress.host
   #defaultConfigVisibilitySettings:
   #- '*'
 

--- a/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/istio-control/istio-autoinject/files/injection-template.yaml
@@ -160,6 +160,9 @@ template: |
   {{- if .Values.global.trustDomain }}
     - --trust-domain={{ .Values.global.trustDomain }}
   {{- end }}
+  {{- if .Values.global.logAsJson }}
+    - --log_as_json
+  {{- end }}
     env:
     - name: POD_NAME
       valueFrom:

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             - --healthCheckFile=/health
             - --webhookConfigName=istio-sidecar-injector-{{ .Release.Namespace }}
             - --log_output_level=debug
+          {{- if .Values.global.logAsJson }}
+            - --log_as_json
+          {{- end }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -127,6 +127,9 @@ spec:
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
         {{- end }}
+        {{- if .Values.global.logAsJson }}
+          - --log_as_json
+        {{- end }}
           env:
           - name: POD_NAME
             valueFrom:

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
 {{- if .Values.global.logging.level }}
           - --log_output_level={{ .Values.global.logging.level }}
 {{- end}}
+{{- if .Values.global.logAsJson }}
+          - --log_as_json
+{{- end }}
           - --domain
           - {{ .Values.global.proxy.clusterDomain }}
 {{- if .Values.global.oneNamespace }}
@@ -152,6 +155,9 @@ spec:
         {{- end }}
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
+        {{- end }}
+        {{- if .Values.global.logAsJson }}
+          - --log_as_json
         {{- end }}
           env:
           - name: POD_NAME

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
 {{- if .Values.global.logging.level }}
           - --log_output_level={{ .Values.global.logging.level }}
 {{- end}}
+{{- if .Values.global.logAsJson }}
+          - --log_as_json
+{{- end }}
 {{- if .Values.global.useMCP }}
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcps://istio-galley.{{ .Values.global.configNamespace }}.svc:15019
@@ -165,6 +168,9 @@ spec:
       {{- end }}
       {{- if .Values.global.trustDomain }}
         - --trust-domain={{ .Values.global.trustDomain }}
+      {{- end }}
+      {{- if .Values.global.logAsJson }}
+        - --log_as_json
       {{- end }}
         env:
         - name: POD_NAME

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
 {{- if .Values.global.logging.level }}
           - --log_output_level={{ .Values.global.logging.level }}
 {{- end}}
+{{- if .Values.global.logAsJson }}
+          - --log_as_json
+{{- end }}
 {{- if .Values.global.useMCP }}
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcp://localhost:15019
@@ -166,6 +169,9 @@ spec:
       {{- end }}
       {{- if .Values.global.trustDomain }}
         - --trust-domain={{ .Values.global.trustDomain }}
+      {{- end }}
+      {{- if .Values.global.logAsJson }}
+        - --log_as_json
       {{- end }}
         env:
         - name: POD_NAME

--- a/kustomize/istio-control/istio-autoinject.yaml
+++ b/kustomize/istio-control/istio-autoinject.yaml
@@ -38,10 +38,10 @@ data:
     policy: enabled
     alwaysInjectSelector:
       []
-      
+
     neverInjectSelector:
       []
-      
+
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       {{- if or (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
@@ -203,6 +203,9 @@ data:
       {{- end }}
       {{- if .Values.global.trustDomain }}
         - --trust-domain={{ .Values.global.trustDomain }}
+      {{- end }}
+      {{- if .Values.global.logAsJson }}
+        - --log_as_json
       {{- end }}
         env:
         - name: POD_NAME
@@ -389,7 +392,7 @@ data:
           - {{ . }}
           {{- end }}
       {{- end }}
-    
+
 
 ---
 # Source: istio-autoinject/templates/serviceaccount.yaml
@@ -534,7 +537,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-            
+
       volumes:
       - name: config-volume
         configMap:
@@ -550,7 +553,7 @@ spec:
             path: config
           - key: values
             path: values
-      affinity:      
+      affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -582,7 +585,7 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - s390x      
+                - s390x
 
 ---
 # Source: istio-autoinject/templates/mutatingwebhook.yaml

--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
           {{- if .Values.workloadCertTtl }}
             - --workload-cert-ttl={{ .Values.workloadCertTtl }}
           {{- end }}
+          {{- if .Values.global.logAsJson }}
+            - --log_as_json
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /version

--- a/security/nodeagent/templates/daemonset.yaml
+++ b/security/nodeagent/templates/daemonset.yaml
@@ -32,6 +32,10 @@ spec:
           image: "{{ .Values.global.hub }}/{{ .Values.nodeagent.image }}:{{ .Values.global.tag }}"
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args:
+          {{- if .Values.global.logAsJson }}
+            - --log_as_json
+          {{- end }}
           volumeMounts:
             - mountPath: /var/run/sds
               name: sdsudspath


### PR DESCRIPTION
Currently there is no option in helm charts to output Istio components logs in JSON format. By default all the component logs are in TEXT format.
Each istio component container have option to change output as JSON using --log_as_json argument but in helm charts there is no way to add this argument

--log_as_json | Whether to format output as JSON or in plain console-friendly format

Added global variable called logAsJson in global.yaml and updated helm charts to use --log_as_json container argument

For reference:
This PR was raised before and tested https://github.com/istio/istio/pull/13678