### PR TITLE
Pass enableNamespacesByDefault to istio config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,8 +299,7 @@ jobs:
       - run:
           command: make sync
       - run:
-          # todo: set ENABLE_NAMESPACES_BY_DEFAULT=false once integration tests can support it
-          command: make kind-run TARGET="install-base"
+          command: make kind-run TARGET="install-base ENABLE_NAMESPACES_BY_DEFAULT=false"
       - run:
           command: make docker-run-test TEST_TARGET="run-minimal-test"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
       - run:
           command: make kind-run TARGET="install-base ENABLE_NAMESPACES_BY_DEFAULT=false"
       - run:
-          command: make docker-run-test TEST_TARGET="run-minimal-test"
+          command: make docker-run-test TEST_TARGET="run-minimal-test ENABLE_NAMESPACES_BY_DEFAULT=false"
       - run:
           when: always
           command: make kind-logs

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ HELM_VER ?= v2.13.1
 # customize base image
 export ISTIOCTL_BIN ?= /usr/local/bin/istioctl
 
+# This enables injection of sidecar in all namespaces with the default sidecar.
+# if it is false, use the specified sidecar.
+ENABLE_NAMESPACES_BY_DEFAULT ?= true
+CUSTOM_SIDECAR_INJECTOR_NAMESPACE ?= 
+
 # Namespace and environment running the control plane.
 # A cluster must support multiple control plane versions.
 ISTIO_SYSTEM_NS ?= istio-system
@@ -86,6 +91,9 @@ ISTIO_TELEMETRY_NS ?= istio-telemetry
 ISTIO_POLICY_NS ?= istio-policy
 ISTIO_INGRESS_NS ?= istio-ingress
 ISTIO_EGRESS_NS ?= istio-egress
+	ifeq ($(ENABLE_NAMESPACES_BY_DEFAULT),false)
+		CUSTOM_SIDECAR_INJECTOR_NAMESPACE = istio-control
+	endif
 endif
 
 # Namespace for running components with admin rights, e.g. kiali

--- a/test/install.mk
+++ b/test/install.mk
@@ -5,8 +5,6 @@
 
 INSTALL_OPTS="--set global.istioNamespace=${ISTIO_CONTROL_NS} --set global.configNamespace=${ISTIO_CONTROL_NS} --set global.telemetryNamespace=${ISTIO_TELEMETRY_NS} --set global.policyNamespace=${ISTIO_POLICY_NS}"
 
-ENABLE_NAMESPACES_BY_DEFAULT ?= true
-
 # Verify each component can be generated. If "ONE_NAMESPACE" is set to 1, then create pre-processed yaml files with the defaults
 # all in "istio-control" namespace, otherwise, create pre-processed yaml in isolated namespaces for different components.
 # TODO: minimize 'ifs' in templates, and generate alternative files for cases we can't remove. The output could be

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -95,7 +95,7 @@ INT_FLAGS ?= \
 	--istio.test.kube.policyNamespace ${ISTIO_POLICY_NS} \
 	--istio.test.kube.ingressNamespace ${ISTIO_INGRESS_NS} \
 	--istio.test.kube.egressNamespace ${ISTIO_EGRESS_NS} \
-	--istio.test.kube.enableNamespacesByDefault ${ENABLE_NAMESPACES_BY_DEFAULT} \
+	--istio.test.kube.customSidecarInjectorNamespace ${CUSTOM_SIDECAR_INJECTOR_NAMESPACE} \
 	--istio.test.kube.minikube \
 	--istio.test.ci -timeout 30m
 
@@ -147,4 +147,5 @@ run-minimal-test:
 			-istio.test.nocleanup \
 			-istio.test.kube.deploy=0 \
 			-istio.test.kube.configNamespace=istio-control \
+			-istio.test.kube.customSidecarInjectorNamespace=${CUSTOM_SIDECAR_INJECTOR_NAMESPACE} \
 			-v)

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -95,6 +95,7 @@ INT_FLAGS ?= \
 	--istio.test.kube.policyNamespace ${ISTIO_POLICY_NS} \
 	--istio.test.kube.ingressNamespace ${ISTIO_INGRESS_NS} \
 	--istio.test.kube.egressNamespace ${ISTIO_EGRESS_NS} \
+	--istio.test.kube.enableNamespacesByDefault ${ENABLE_NAMESPACES_BY_DEFAULT} \
 	--istio.test.kube.minikube \
 	--istio.test.ci -timeout 30m
 

--- a/test/tests.mk
+++ b/test/tests.mk
@@ -95,7 +95,7 @@ INT_FLAGS ?= \
 	--istio.test.kube.policyNamespace ${ISTIO_POLICY_NS} \
 	--istio.test.kube.ingressNamespace ${ISTIO_INGRESS_NS} \
 	--istio.test.kube.egressNamespace ${ISTIO_EGRESS_NS} \
-	--istio.test.kube.customSidecarInjectorNamespace ${CUSTOM_SIDECAR_INJECTOR_NAMESPACE} \
+	--istio.test.kube.customSidecarInjectorNamespace=${CUSTOM_SIDECAR_INJECTOR_NAMESPACE} \
 	--istio.test.kube.minikube \
 	--istio.test.ci -timeout 30m
 


### PR DESCRIPTION
in this PR https://github.com/istio/istio/pull/15284, we enable get `enableNamespacesByDefault` from command line. pass this value in the new installer to enable test with `enableNamespacesByDefault` is false

Signed-off-by: clyang82 <clyang@cn.ibm.com>