### PR TITLE
Fixed: pod cannot direct traffic to itself via a service

### DIFF
--- a/bin/testEnvRootMinikube.sh
+++ b/bin/testEnvRootMinikube.sh
@@ -93,6 +93,8 @@ function startMinikubeNone() {
          --extra-config=apiserver.enable-admission-plugins="NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
     sudo -E minikube update-context
     sudo chown -R "$(id -u)" "$KUBECONFIG" "$HOME/.minikube"
+    # workaround method to enable pod can direct traffic to itself via a service 
+    sudo ip link set docker0 promisc on
 }
 
 function stopMinikube() {


### PR DESCRIPTION
There are some issues logged in minikube community about pod cannot direct traffic to itself via a service. refer to:
https://github.com/kubernetes/minikube/issues/1568
https://github.com/kubernetes/kubernetes/issues/20475

Propose to apply this workaround method to fix - `
ci/circleci: install-minikube — Your tests failed on CircleCI `

Signed-off-by: clyang82 <clyang@cn.ibm.com>