### PR TITLE
fix missing crds for certmanager.

### DIFF
--- a/crds/templates/crds.yaml
+++ b/crds/templates/crds.yaml
@@ -3,5 +3,5 @@
 {{ .Files.Get "files/crd-12.yaml" }}
 {{- if .Values.certmanager.enabled }}
 {{ .Files.Get "files/crd-certmanager-10.yaml" }}
-{{ .Files.Get "files/crd-certmanager-10.yaml" }}
+{{ .Files.Get "files/crd-certmanager-11.yaml" }}
 {{- end }}

--- a/crds/templates/crds.yaml
+++ b/crds/templates/crds.yaml
@@ -1,3 +1,7 @@
 {{ .Files.Get "files/crd-10.yaml" }}
 {{ .Files.Get "files/crd-11.yaml" }}
 {{ .Files.Get "files/crd-12.yaml" }}
+{{- if .Values.certmanager.enabled }}
+{{ .Files.Get "files/crd-certmanager-10.yaml" }}
+{{ .Files.Get "files/crd-certmanager-10.yaml" }}
+{{- end }}


### PR DESCRIPTION
Sync the cert-manager crds changes from istio-operator https://github.com/istio/operator/pull/69

Although the CI for new installer apply all crds with `kubectl`, it's necessary add crds for cert-manager in chart template, because the istio-operator renders all the CRDs with crds chart.

