### PR TITLE
feat(tracing): add alpha support for opencensus service

### DIFF
--- a/istio-telemetry/tracing/templates/deployment-opencensus.yaml
+++ b/istio-telemetry/tracing/templates/deployment-opencensus.yaml
@@ -1,0 +1,94 @@
+{{ if eq .Values.tracing.provider "opencensus" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oc-collector-config
+  labels:
+    app: opencensus
+    component: oc-collector-config
+data:
+  oc-collector-config: |
+    receivers:
+      zipkin:
+        address: "127.0.0.1:9411"
+    exporters:
+{{- if .Values.tracing.opencensus.exporters }}
+{{ toYaml .Values.tracing.opencensus.exporters | indent 6 }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-tracing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: opencensus
+    component: oc-collector
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: opencensus
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app: opencensus
+        component: oc-collector
+    spec:
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
+{{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
+      containers:
+      - name: oc-collector
+        image: "{{ .Values.tracing.opencensus.hub }}/opencensus-collector:{{ .Values.tracing.opencensus.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Always" }}
+        command:
+          - "/occollector_linux"
+          - "--config=/conf/oc-collector-config.yaml"
+        ports:
+        - containerPort: 9411
+        resources:
+{{- if .Values.tracing.opencensus.resources }}
+{{ toYaml .Values.tracing.opencensus.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
+        volumeMounts:
+        - name: oc-collector-config-vol
+          mountPath: /conf
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        env:
+        - name: GOGC
+          value: "80"
+      volumes:
+        - configMap:
+            name: oc-collector-config
+            items:
+              - key: oc-collector-config
+                path: oc-collector-config.yaml
+          name: oc-collector-config-vol
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
+      {{- include "podAntiAffinity" . | indent 6 }}
+{{ end }}

--- a/istio-telemetry/tracing/templates/service.yaml
+++ b/istio-telemetry/tracing/templates/service.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     app: {{ .Values.tracing.provider }}
 ---
+{{- if ne .Values.tracing.provider "opencensus"}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,3 +41,4 @@ spec:
 {{ end}}
   selector:
     app: {{ .Values.tracing.provider }}
+{{- end }}

--- a/istio-telemetry/tracing/values.yaml
+++ b/istio-telemetry/tracing/values.yaml
@@ -55,6 +55,20 @@ tracing:
     node:
       cpus: 2
 
+  opencensus:
+    hub: docker.io/omnition
+    tag: 0.1.9
+    resources:
+      limits:
+        cpu: 1
+        memory: 2Gi
+      requests:
+        cpu: 200m
+        memory: 400Mi
+    exporters:
+      stackdriver:
+        enable_tracing: true
+
   service:
     annotations: {}
     name: http


### PR DESCRIPTION
This PR adds a third option for the application backing the `zipkin` service for Istio: the [OpenCensus Service](https://opencensus.io/service/) (with a `zipkin` receiver).

In this PR, we deploy the [collector](https://opencensus.io/service/components/collector/), configured with a [receiver](https://opencensus.io/service/receivers/) for `zipkin`. At the moment, the sole [exporter](https://opencensus.io/service/exporters/) configuration supported is `stackdriver`. However, that section can be extended.

Notably, the OC service does not expose a UI, so if the provider is set to `opencensus` the artifact for the tracing UI service is not generated.