### PR TITLE
Add sidecars for kiali

### DIFF
--- a/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -83,6 +83,7 @@ rules:
       - destinationrules
       - gateways
       - serviceentries
+      - sidecars
       - virtualservices
     verbs:
       - create
@@ -205,6 +206,7 @@ rules:
       - destinationrules
       - gateways
       - serviceentries
+      - sidecars
       - virtualservices
     verbs:
       - get


### PR DESCRIPTION
Add the missed sidecars in kiali clusterrole.yaml file. 