### PR TITLE
Adding version to pilot,injector - allowing same namespace multi version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,4 +309,5 @@ include test/install.mk
 include test/tests.mk
 include test/noauth.mk
 include test/demo.mk
+include test/inplace/inplace.mk
 include Makefile.common.mk

--- a/crds/kustomization.yaml
+++ b/crds/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
   - files/crd-12.yaml
   - files/crd-certmanager-10.yaml
   - files/crd-certmanager-11.yaml
+  - files/namespaces.yaml
+  - files/clusterrole-12.yaml
+  - files/clusterrolebinding-12.yaml
+  - files/serviceaccounts-12.yaml
+
+commonLabels:
+  release: istio-cluster

--- a/global.yaml
+++ b/global.yaml
@@ -14,19 +14,13 @@
 
 global:
   # Used to locate istio-pilot.
-  # Default is to install pilot in a dedicated namespace, istio-pilot11. You can use multiple namespaces, but
-  # for each 'profile' you need to match the control plane namespace and the value of istioNamespace
-  # It is assumed that istio-system is running either 1.0 or an upgraded version of 1.1, but only security components are
-  # used (citadel generating the secrets).
-  istioNamespace: istio-control
-  configNamespace: istio-control
-
-  # Telemetry namespace, including tracing.
-  telemetryNamespace: istio-telemetry
-
-  prometheusNamespace: istio-telemetry
-
-  policyNamespace: istio-policy
+  # Default is to install pilot in istio-system, for backward compatibility.
+  # You can use also multiple namespaces.
+  istioNamespace: istio-system
+  configNamespace: istio-system
+  telemetryNamespace: istio-system
+  prometheusNamespace: istio-system
+  policyNamespace: istio-system
 
 
   ## End new settings
@@ -409,3 +403,14 @@ global:
   # This field is set to false by default, so 'helm template ...'
   # will ignore the helm test yaml files when generating the template
   enableHelmTest: false
+
+# Internal setting - used when generating helm templates for kustomize.
+# clusterResources controls the inclusion of cluster-wide resources when generating the charts/installing.
+# For backward compat, it is set to 'true', resulting in the old-style installation.
+# When set to 'false', all cluster-wide resources will be omitted, and are expected to be installed
+# at the same time with the CRDs.
+clusterResources: true
+
+# Version is set as 'version' label and part of the resource names when installing.
+# It is used to support multiple version in same namespace, similar with normal app traffic shift.
+version: default

--- a/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/istio-control/istio-autoinject/files/injection-template.yaml
@@ -13,10 +13,6 @@ template: |
   {{- end }}
     command:
     - "/usr/local/bin/istio-iptables.sh"
-    - "-p"
-    - "{{ .MeshConfig.ProxyListenPort }}"
-    - "-u"
-    - 1337
     - "-m"
     - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
     - "-i"
@@ -35,6 +31,15 @@ template: |
     - "-k"
     - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
     {{ end -}}
+    env:
+       - name: ENVOY_PORT
+         value: {{ .MeshConfig.ProxyListenPort }}
+       - name: PROXY_UID
+         value: 1337
+      {{- if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` "") }}
+       - name: INBOUND_CAPTURE_PORT
+         value: 15006
+      {{ end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
     resources:
       requests:
@@ -192,6 +197,8 @@ template: |
           fieldPath: metadata.namespace
     - name: ISTIO_META_INTERCEPTION_MODE
       value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+    - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+      value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
     {{- if .Values.global.network }}
     - name: ISTIO_META_NETWORK
       value: "{{ .Values.global.network }}"
@@ -225,11 +232,12 @@ template: |
       failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
     {{ end -}}
     securityContext:
-      {{- if .Values.global.proxy.privileged }}
+      {{- if (annotation .ObjectMeta `status.sidecar.istio.io/privileged` .Values.global.proxy.privileged) }}
       privileged: true
-      {{- end }}
+      {{ else }}
       {{- if ne .Values.global.proxy.enableCoreDump true }}
       readOnlyRootFilesystem: true
+      {{- end }}
       {{- end }}
       {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
       capabilities:

--- a/istio-control/istio-autoinject/templates/clusterrole.yaml
+++ b/istio-control/istio-autoinject/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -15,3 +16,4 @@ rules:
   resources: ["mutatingwebhookconfigurations"]
   resourceNames: ["istio-sidecar-injector-{{.Release.Namespace}}"]
   verbs: ["get", "list", "watch", "patch"]
+{{ end }}

--- a/istio-control/istio-autoinject/templates/clusterrolebinding.yaml
+++ b/istio-control/istio-autoinject/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,3 +15,4 @@ subjects:
   - kind: ServiceAccount
     name: istio-sidecar-injector-service-account
     namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -1,17 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: sidecar-injector
     release: {{ .Release.Name }}
     istio: sidecar-injector
+    version: {{ .Values.version }}
 spec:
   replicas: {{ .Values.sidecarInjectorWebhook.replicaCount }}
   selector:
     matchLabels:
       istio: sidecar-injector
+      version: {{ .Values.version }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -20,6 +22,7 @@ spec:
     metadata:
       labels:
         app: sidecarInjectorWebhook
+        version: {{ .Values.version }}
         istio: sidecar-injector
 {{- if eq .Release.Namespace "istio-system"}}
         heritage: Tiller
@@ -92,7 +95,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: istio
+          name: istio-{{ .Values.version }}
       - name: certs
         secret:
 {{- if .Values.sidecarInjectorWebhook.selfSigned }}
@@ -102,7 +105,7 @@ spec:
 {{- end }}
       - name: inject-config
         configMap:
-          name: istio-sidecar-injector
+          name: istio-sidecar-injector-{{ .Values.version }}
           items:
           - key: config
             path: config

--- a/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
+++ b/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
@@ -1,8 +1,9 @@
+{{ if not .Values.skipWebhook }}
 {{- $ca := genCA "istio-sidecar-injector-ca-{{ .Release.Namespace }}" 3650 }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector-{{ .Release.Namespace }}
+  name: istio-sidecar-injector-{{ .Release.Namespace }}-{{ .Values.version }}
   labels:
     app: sidecar-injector
     release: {{ .Release.Name }}
@@ -10,7 +11,7 @@ webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
-        name: istio-sidecar-injector
+        name: istio-sidecar-injector-{{ .Values.version }}
         namespace: {{ .Release.Namespace }}
         path: "/inject"
 {{- if .Values.sidecarInjectorWebhook.selfSigned }}
@@ -39,7 +40,7 @@ webhooks:
         operator: DoesNotExist
 {{- else }}
       matchLabels:
-        istio-env: {{ .Release.Namespace }}
+        istio-env: {{ .Release.Namespace }}-{{ .Values.version }}
 {{- end }}
 ---
 {{- if .Values.sidecarInjectorWebhook.selfSigned }}
@@ -61,4 +62,5 @@ data:
   root-cert.pem: {{ $ca.Cert | b64enc }}
   cert-chain.pem: {{ $cert.Cert | b64enc }}
   key.pem: {{ $cert.Key | b64enc }}
+{{- end }}
 {{- end }}

--- a/istio-control/istio-autoinject/templates/poddisruptionbudget.yaml
+++ b/istio-control/istio-autoinject/templates/poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: sidecar-injector
@@ -15,4 +15,5 @@ spec:
       app: sidecar-injector
       release: {{ .Release.Name }}
       istio: sidecar-injector
+      version: {{ .Values.version }}
 {{- end }}

--- a/istio-control/istio-autoinject/templates/service.yaml
+++ b/istio-control/istio-autoinject/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: sidecar-injector
@@ -12,3 +12,4 @@ spec:
   - port: 443
   selector:
     istio: sidecar-injector
+    version: {{ .Values.version }}

--- a/istio-control/istio-autoinject/templates/serviceaccount.yaml
+++ b/istio-control/istio-autoinject/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -13,3 +14,4 @@ metadata:
     app: sidecar-injector
     release: {{ .Release.Name }}
     istio: sidecar-injector
+{{ end }}

--- a/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
+++ b/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}

--- a/istio-control/istio-config/templates/clusterrole.yaml
+++ b/istio-control/istio-config/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -35,4 +36,4 @@ rules:
   resourceNames: ["istio-galley"]
   verbs: ["update"]
 ---
-
+{{ end }}

--- a/istio-control/istio-config/templates/clusterrolebinding.yaml
+++ b/istio-control/istio-config/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
     name: istio-galley-service-account
     namespace: {{ .Release.Namespace }}
 ---
+{{ end }}

--- a/istio-control/istio-config/templates/configmap-envoy.yaml
+++ b/istio-control/istio-config/templates/configmap-envoy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: galley-envoy-config
+  name: galley-envoy-config-{{ .Values.version }}
   labels:
     app: galley
     istio: galley

--- a/istio-control/istio-config/templates/configmap-mesh.yaml
+++ b/istio-control/istio-config/templates/configmap-mesh.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-mesh-galley
+  name: istio-mesh-galley-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}

--- a/istio-control/istio-config/templates/configmap.yaml
+++ b/istio-control/istio-config/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-galley-configuration
+  name: istio-galley-configuration-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -1,11 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-galley
+  name: istio-galley-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     istio: galley
+    version: {{ .Values.version }}
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.galley.replicaCount }}
@@ -13,6 +14,7 @@ spec:
     matchLabels:
       app: galley
       istio: galley
+      version: {{ .Values.version }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -21,6 +23,7 @@ spec:
     metadata:
       labels:
         app: galley
+        version: {{ .Values.version }}
         istio: galley
 {{- if eq .Release.Namespace "istio-system"}}
         heritage: Tiller
@@ -169,16 +172,16 @@ spec:
           secretName: istio.istio-galley-service-account
       - name: envoy-config
         configMap:
-          name: galley-envoy-config
+          name: galley-envoy-config-{{ .Values.version }}
   {{- end }}
       - name: config
         configMap:
-          name: istio-galley-configuration
+          name: istio-galley-configuration-{{ .Values.version }}
       # Different config map from pilot, to allow independent config and rollout.
       # Both are derived from values.yaml.
       - name: mesh-config
         configMap:
-          name: istio-mesh-galley
+          name: istio-mesh-galley-{{ .Values.version }}
 
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/istio-control/istio-config/templates/poddisruptionbudget.yaml
+++ b/istio-control/istio-config/templates/poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-galley
+  name: istio-galley-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: galley
@@ -15,6 +15,6 @@ spec:
       app: galley
       release: {{ .Release.Name }}
       istio: galley
+      version: {{ .Values.version }}
 ---
-
 {{- end }}

--- a/istio-control/istio-config/templates/service.yaml
+++ b/istio-control/istio-config/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-galley
+  name: istio-galley-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: galley
@@ -19,4 +19,5 @@ spec:
     name: grpc-tls-mcp
   selector:
     istio: galley
+    version: {{ .Values.version }}
 ---

--- a/istio-control/istio-config/templates/serviceaccount.yaml
+++ b/istio-control/istio-config/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -13,3 +14,4 @@ metadata:
     app: galley
     release: {{ .Release.Name }}
 ---
+{{ end }}

--- a/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-galley-{{ .Release.Namespace }}
+  name: istio-galley-{{ .Release.Namespace }}-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: galley

--- a/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/istio-control/istio-discovery/templates/autoscale.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istio-pilot
+  name: istio-pilot-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: pilot
@@ -13,7 +13,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: istio-pilot
+    name: istio-pilot-{{ .Values.version }}
   metrics:
   - type: Resource
     resource:

--- a/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -31,3 +32,4 @@ rules:
   resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
   verbs: ["get", "list", "watch"]
 ---
+{{ end }}

--- a/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,3 +15,4 @@ subjects:
     name: istio-pilot-service-account
     namespace: {{ .Release.Namespace }}
 ---
+{{ end }}

--- a/istio-control/istio-discovery/templates/configmap-envoy.yaml
+++ b/istio-control/istio-discovery/templates/configmap-envoy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: pilot-envoy-config
+  name: pilot-envoy-config-{{ .Values.version }}
   labels:
     release: {{ .Release.Name }}
 data:
@@ -63,7 +63,7 @@ data:
 
         hosts:
           - socket_address:
-              address: istio-galley.{{ .Values.global.configNamespace }}
+              address: istio-galley-{{ .Values.version }}.{{ .Values.global.configNamespace }}
               port_value: 15019
 
 

--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio
+  name: istio-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -1,17 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-pilot
+  name: istio-pilot-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
+    version: {{ .Values.version }}
     release: {{ .Release.Name }}
 {{- range $key, $val := .Values.pilot.deploymentLabels }}
     {{ $key }}: "{{ $val }}"
 {{- end }}
     istio: pilot
   annotations:
+    checksum/config-volume-envoy:  {{ include (print $.Template.BasePath "/configmap-envoy.yaml") . | sha256sum }}
     checksum/config-volume:  {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
 {{- if not .Values.pilot.autoscaleEnabled }}
@@ -32,6 +34,7 @@ spec:
     metadata:
       labels:
         app: pilot
+        version: {{ .Values.version }}
         istio: pilot
 {{- if eq .Release.Namespace "istio-system"}}
         heritage: Tiller
@@ -214,8 +217,8 @@ spec:
       {{- end }}
       - name: config-volume
         configMap:
-          name: istio
-      - name: pilot-envoy-config
+          name: istio-{{ .Values.version }}
+      - name: pilot-envoy-config-{{ .Values.version }}
         configMap:
           name: pilot-envoy-config
   {{- if .Values.global.controlPlaneSecurityEnabled}}

--- a/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
 # Customer should add similar destination rules for other services that dont' have sidecar.
 apiVersion: networking.istio.io/v1alpha3
@@ -78,4 +79,5 @@ spec:
       mode: DISABLE
 ---
 
+{{ end }}
 {{ end }}

--- a/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-pilot
+  name: istio-pilot-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: pilot
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       app: pilot
+      version: {{ .Values.version }}
       release: {{ .Release.Name }}
       istio: pilot
 ---

--- a/istio-control/istio-discovery/templates/service.yaml
+++ b/istio-control/istio-discovery/templates/service.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
+  name: istio-pilot-{{ .Values.version }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: pilot
+    version: {{ .Values.version }}
     release: {{ .Release.Name }}
     istio: pilot
 spec:
@@ -19,4 +20,5 @@ spec:
     name: http-monitoring
   selector:
     istio: pilot
+    version: {{ .Values.version }}
 ---

--- a/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -13,3 +14,4 @@ metadata:
     app: pilot
     release: {{ .Release.Name }}
 ---
+{{ end }}

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,15 +1,117 @@
-# Experimental Kustomize support
+# Kustomize support
 
-Organization: each directory corresponds to a namespace ( 'environment' ).
+Organization: each directory corresponds to a a-la-carte component or a set of components ('profile').
 
-Inside each component will have a directory, named to match the name of the directory where the helm template is defined.
- 
-A 'kustomization.yaml' file inside the directory can apply the normal kustomize rules. It should expect a 'k8s.yaml' 
-resource.
+Inside there is a "kustomization.yaml" file, some patches or other source files, and one generated 
+file - currently matching the name of the directory ( ex. istio-ingress/istio-ingress.yaml). 
 
-# Usage
+TODO: use a gen- prefix for generated yaml files.
 
-"helm template" will be used with the normal values/global/user settings, and generate a k8s.yaml file under 
+** The number of possible options and settings is restricted to what kustomize supports.  Many of Istio 
+values.yaml configurations that are reflected into CLI or config maps are difficult to support in kustomize **
+
+# User experience
+
+Basic install:
+```bash
+kubectl apply --prune -l a=b github.com/istio/install/kustomize/NAME
+
+```
+
+Local kustomizations: create a local kustomize.yaml file, with any patches and changes supported by kustomize:
+
+```yaml
+
+
+```
+
+# Components (a-la-carte)
+
+Each 'a-la-carte' profile deploys one istio microservice. Intended for advanced users who want 
+to install istio with full control, and for 'operator'.
+
+## cluster
+
+Contains cluster-wide resources - cluster roles, istio-system namespace, service accounts, bindings.
+It includes no deployments or services.
+
+Must be installed first.
+
+Required unless istio-1.2 or later installed with the old installer is already present. 
+
+IMPORTANT: in upgrade cases you can't simply remove the previous version of istio, since this would delete
+cluster-wide resources. The proper way is to disable the deployments ( in progress )
+
+## citadel
+
+Should be installed after the cluster resources, and before all other components. 
+
+Operator should wait for service account secrets to be created before installing the next component.  
+
+## sds-agent
+
+Optional, creates a DaemonSet that enables node SDS. 
+
+## istio-ingress
+
+Ingress.
+
+## pilot
+
+Installs istio-pilot.  
+
+## autoinject
+
+Install an opt-in auto-injector, enabled by using a namespace label
+
+```yaml
+  labels:
+    istio-env: istio-system-default
+```
+
+
+## cluster-autoinject
+
+Installs a global auto-injector. User can opt-out:
+
+```yaml
+  labels:
+    istio-injection: disabled
+```
+
+or select a specific 'opt-in' profile:
+
+```yaml
+  labels:
+    istio-env: istio-system-default
+```
+
+# Profiles 
+
+Profiles install sets of components.
+
+## demo
+
+Equivalent with the demo from 1.2. Almost all components installed. 
+
+## micro
+
+Installs only Pilot and Ingress. Should only be used on secure networks (IPSec or other security provided 
+by the CNI), since it doesn't include Citadel or mtls support. 
+
+## istio-canary
+
+Installs a canary version of pilot and injector, alongside an existing 1.2 or 1.3 "old installer" istio.
+
+
+# Implementation
+
+"helm template" will be used with the normal values/global/user settings, and generate a file under 
 $OUT/$NAMESPACE/$COMPONENT
 
 If the kustomize file exists, it will be applied before running "kubectl apply --prune".
+
+# Dependencies
+
+This requires v1.14 version of kubectl, or the matching kustomize version (2.0.3).
+

--- a/kustomize/citadel/citadel.yaml
+++ b/kustomize/citadel/citadel.yaml
@@ -12,6 +12,7 @@ metadata:
 
 ---
 # Source: citadel/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -29,6 +30,7 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["get", "watch", "list"]
+
 
 ---
 # Source: citadel/templates/clusterrolebinding.yaml

--- a/kustomize/citadel/kustomization.yaml
+++ b/kustomize/citadel/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
   - citadel.yaml
 
 # Must be installed in istio-system to preserve secrets, it is a singleton.

--- a/kustomize/citadel/namespace.yaml
+++ b/kustomize/citadel/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-injection: disabled

--- a/kustomize/istio-control/discovery/discovery.yaml
+++ b/kustomize/istio-control/discovery/discovery.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-control
   labels:
     app: pilot
@@ -15,6 +15,7 @@ spec:
   selector:
     matchLabels:
       app: pilot
+      version: default
       release: istio-control-istio-discovery
       istio: pilot
 
@@ -24,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: istio-control
-  name: pilot-envoy-config
+  name: pilot-envoy-config-default
   labels:
     release: istio-control-istio-discovery
 data:
@@ -54,10 +55,6 @@ data:
             max_requests: 100000
             max_retries: 3
 
-    # TODO: telemetry using EDS
-    # TODO: other pilots using EDS, load balancing
-    # TODO: galley using EDS
-
       - name: out.galley.15019
         http2_protocol_options: {}
         connect_timeout: 1.000s
@@ -81,11 +78,11 @@ data:
               trusted_ca:
                 filename: /etc/certs/root-cert.pem
               verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-control/sa/istio-galley-service-account
+              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
 
         hosts:
           - socket_address:
-              address: istio-galley.istio-control
+              address: istio-galley-default.istio-system
               port_value: 15019
 
 
@@ -135,19 +132,17 @@ data:
           tls_context:
             require_client_certificate: true
             common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/certs/root-cert.pem
-
               alpn_protocols:
               - h2
 
+              validation_context:
+                trusted_ca:
+                  filename: /etc/certs/root-cert.pem
               tls_certificates:
               - certificate_chain:
                   filename: /etc/certs/cert-chain.pem
                 private_key:
                   filename: /etc/certs/key.pem
-
 
       # Manual 'whitebox' mode
       - name: "local.15019"
@@ -195,7 +190,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio
+  name: istio-default
   namespace: istio-control
   labels:
     release: istio-control-istio-discovery
@@ -254,8 +249,8 @@ data:
     reportBatchMaxEntries: 100
     # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
     reportBatchMaxTime: 1s
-    mixerReportServer: istio-telemetry.istio-telemetry.svc.cluster.local:15004
-    mixerCheckServer: istio-policy.istio-policy.svc.cluster.local:15004
+    mixerReportServer: istio-telemetry.istio-system.svc.cluster.local:15004
+    mixerCheckServer: istio-policy.istio-system.svc.cluster.local:15004
 
     disablePolicyChecks: true
 
@@ -264,9 +259,22 @@ data:
     ingressService: "istio-ingressgateway"
     ingressControllerMode: "OFF"
     ingressClass: "istio"
+    # Set expected values when SDS is disabled
     # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get
     # key/cert for mTLS. Use secret-mount files instead of SDS if set to empty.
-    sdsUdsPath: 
+    sdsUdsPath: ""
+    # This flag is used by secret discovery service(SDS).
+    # If set to true(prerequisite: https://kubernetes.io/docs/concepts/storage/volumes/#projected), Istio will inject volumes mount
+    # for k8s service account JWT, so that K8s API server mounts k8s service account JWT to envoy container, which
+    # will be used to generate key/cert eventually. This isn't supported for non-k8s case.
+    enableSdsTokenMount: false
+    # This flag is used by secret discovery service(SDS).
+    # If set to true, envoy will fetch normal k8s service account JWT from '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    # (https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
+    # and pass to sds server, which will be used to request key/cert eventually.
+    # this flag is ignored if enableSdsTokenMount is set.
+    # This isn't supported for non-k8s case.
+    sdsUseK8sSaJwt: false
     config_sources:
     - address: localhost:15019
 
@@ -307,7 +315,7 @@ data:
       tracing:
         zipkin:
           # Address of the Zipkin collector
-          address: zipkin.istio-telemetry:9411
+          address: zipkin.istio-system:9411
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: MUTUAL_TLS
@@ -317,6 +325,7 @@ data:
 
 ---
 # Source: istio-discovery/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -325,9 +334,12 @@ metadata:
   labels:
     app: pilot
     release: istio-control-istio-discovery
+---
+
 
 ---
 # Source: istio-discovery/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -360,9 +372,12 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
   verbs: ["get", "list", "watch"]
+---
+
 
 ---
 # Source: istio-discovery/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -379,15 +394,17 @@ subjects:
     name: istio-pilot-service-account
     namespace: istio-control
 
+
 ---
 # Source: istio-discovery/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-control
   labels:
     app: pilot
+    version: default
     release: istio-control-istio-discovery
     istio: pilot
 spec:
@@ -402,21 +419,24 @@ spec:
     name: http-monitoring
   selector:
     istio: pilot
+    version: default
 
 ---
 # Source: istio-discovery/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-control
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
+    version: default
     release: istio-control-istio-discovery
     istio: pilot
   annotations:
-    checksum/config-volume:  c20ce28acd114c762cba065c6107f355d66db3e93c5e73d37fe13bfb62846449
+    checksum/config-volume-envoy:  b6cb0f305cba1108758857fd91ff19cbc28cb8acbba8295514efd81866e2ff58
+    checksum/config-volume:  eab9381273943889fcb3ac96508b9288e368e630af1af03649b8052bca22448b
 spec:
   strategy:
     rollingUpdate:
@@ -429,6 +449,7 @@ spec:
     metadata:
       labels:
         app: pilot
+        version: default
         istio: pilot
       annotations:
         sidecar.istio.io/inject: "false"
@@ -530,19 +551,28 @@ spec:
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
+          # Config map with the pilot envoy config
           - name: pilot-envoy-config
             mountPath: /var/lib/envoy
+
       volumes:
-      - name: config-volume
-        configMap:
-          name: istio
-      - name: pilot-envoy-config
-        configMap:
-          name: pilot-envoy-config
+
       - name: istio-certs
         secret:
           secretName: istio.istio-pilot-service-account
           optional: true
+
+      # Custom envoy config, for sidecar
+      - name: pilot-envoy-config
+        configMap:
+          name: pilot-envoy-config-default # Setting for control-plane-security enabled: certs or sds, custom envoy config
+
+      # Mesh config
+      - name: config-volume
+        configMap:
+          name: istio-default
+
+
       affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -579,6 +609,7 @@ spec:
 
 ---
 # Source: istio-discovery/templates/enable-mesh-mtls.yaml
+
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
 # Customer should add similar destination rules for other services that dont' have sidecar.
 apiVersion: networking.istio.io/v1alpha3
@@ -625,13 +656,14 @@ spec:
 
 
 
+
 ---
 # Source: istio-discovery/templates/autoscale.yaml
 
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-control
   labels:
     app: pilot
@@ -642,7 +674,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: istio-pilot
+    name: istio-pilot-default
   metrics:
   - type: Resource
     resource:

--- a/kustomize/istio-control/istio-autoinject.yaml
+++ b/kustomize/istio-control/istio-autoinject.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-default
   namespace: istio-control
   labels:
     app: sidecar-injector
@@ -17,6 +17,7 @@ spec:
       app: sidecar-injector
       release: istio-control-istio-autoinject
       istio: sidecar-injector
+      version: default
 
 ---
 # Source: istio-autoinject/templates/sidecar-injector-configmap.yaml
@@ -24,7 +25,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-default
   namespace: istio-control
   labels:
     release: istio-control-istio-autoinject
@@ -32,16 +33,16 @@ metadata:
     istio: sidecar-injector
 data:
   values: |-
-    {"global":{"arch":{"amd64":2,"ppc64le":2,"s390x":2},"configNamespace":"istio-control","configValidation":true,"controlPlaneSecurityEnabled":true,"defaultNodeSelector":{},"defaultPodDisruptionBudget":{"enabled":true},"defaultResources":{"requests":{"cpu":"10m"}},"disablePolicyChecks":true,"enableHelmTest":false,"enableTracing":true,"hub":"gcr.io/istio-release","imagePullPolicy":"Always","imagePullSecrets":null,"istioNamespace":"istio-control","k8sIngress":{"enableHttps":false,"enabled":false,"gatewayName":"ingressgateway"},"localityLbSetting":{},"logging":{"level":"default:info"},"meshExpansion":{"enabled":false,"useILB":false},"meshNetworks":{},"mtls":{"enabled":false},"multiCluster":{"enabled":false},"oneNamespace":false,"outboundTrafficPolicy":{"mode":"ALLOW_ANY"},"policyCheckFailOpen":false,"policyNamespace":"istio-policy","priorityClassName":"","prometheusNamespace":"istio-telemetry","proxy":{"accessLogEncoding":"TEXT","accessLogFile":"","accessLogFormat":"","autoInject":"enabled","clusterDomain":"cluster.local","componentLogLevel":"misc:error","concurrency":2,"dnsRefreshRate":"300s","enableCoreDump":false,"envoyMetricsService":{"enabled":false,"host":null,"port":null},"envoyStatsd":{"enabled":false,"host":null,"port":null},"excludeIPRanges":"","excludeInboundPorts":"","excludeOutboundPorts":"","image":"proxyv2","includeIPRanges":"*","includeInboundPorts":"*","kubevirtInterfaces":"","logLevel":"warning","privileged":false,"readinessFailureThreshold":30,"readinessInitialDelaySeconds":1,"readinessPeriodSeconds":2,"resources":{"limits":{"cpu":"2000m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"statusPort":15020,"tracer":"zipkin"},"proxy_init":{"image":"proxy_init"},"sds":{"enabled":false,"udsPath":"","useNormalJwt":false,"useTrustworthyJwt":false},"tag":"master-latest-daily","telemetryNamespace":"istio-telemetry","tracer":{"datadog":{"address":"$(HOST_IP):8126"},"lightstep":{"accessToken":"","address":"","cacertPath":"","secure":true},"zipkin":{"address":""}},"trustDomain":"","useMCP":true},"istio_cni":{"enabled":false},"sidecarInjectorWebhook":{"alwaysInjectSelector":[],"enableNamespacesByDefault":false,"image":"sidecar_injector","neverInjectSelector":[],"nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"rewriteAppHTTPProbe":false,"selfSigned":false,"tolerations":[]}}
+    {"clusterResources":true,"global":{"arch":{"amd64":2,"ppc64le":2,"s390x":2},"configNamespace":"istio-system","configValidation":true,"controlPlaneSecurityEnabled":true,"defaultNodeSelector":{},"defaultPodDisruptionBudget":{"enabled":true},"defaultResources":{"requests":{"cpu":"10m"}},"disablePolicyChecks":true,"enableHelmTest":false,"enableTracing":true,"hub":"gcr.io/istio-release","imagePullPolicy":"Always","imagePullSecrets":null,"istioNamespace":"istio-system","k8sIngress":{"enableHttps":false,"enabled":false,"gatewayName":"ingressgateway"},"localityLbSetting":{},"logAsJson":false,"logging":{"level":"default:info"},"meshExpansion":{"enabled":false,"useILB":false},"meshNetworks":{},"mtls":{"enabled":false},"multiCluster":{"enabled":false},"oneNamespace":false,"outboundTrafficPolicy":{"mode":"ALLOW_ANY"},"policyCheckFailOpen":false,"policyNamespace":"istio-system","priorityClassName":"","prometheusNamespace":"istio-system","proxy":{"accessLogEncoding":"TEXT","accessLogFile":"","accessLogFormat":"","autoInject":"enabled","clusterDomain":"cluster.local","componentLogLevel":"misc:error","concurrency":2,"dnsRefreshRate":"300s","enableCoreDump":false,"envoyMetricsService":{"enabled":false,"host":null,"port":null},"envoyStatsd":{"enabled":false,"host":null,"port":null},"excludeIPRanges":"","excludeInboundPorts":"","excludeOutboundPorts":"","image":"proxyv2","includeIPRanges":"*","includeInboundPorts":"*","kubevirtInterfaces":"","logLevel":"warning","privileged":false,"readinessFailureThreshold":30,"readinessInitialDelaySeconds":1,"readinessPeriodSeconds":2,"resources":{"limits":{"cpu":"2000m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"statusPort":15020,"tracer":"zipkin"},"proxy_init":{"image":"proxy_init"},"sds":{"enabled":false,"udsPath":"unix:/var/run/sds/uds_path","useNormalJwt":true,"useTrustworthyJwt":false},"tag":"master-latest-daily","telemetryNamespace":"istio-system","tracer":{"datadog":{"address":"$(HOST_IP):8126"},"lightstep":{"accessToken":"","address":"","cacertPath":"","secure":true},"zipkin":{"address":""}},"trustDomain":"","useMCP":true},"istio_cni":{"enabled":false},"sidecarInjectorWebhook":{"alwaysInjectSelector":[],"enableNamespacesByDefault":false,"image":"sidecar_injector","neverInjectSelector":[],"nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"rewriteAppHTTPProbe":false,"selfSigned":false,"tolerations":[]},"version":"default"}
 
   config: |-
     policy: enabled
     alwaysInjectSelector:
       []
-
+      
     neverInjectSelector:
       []
-
+      
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       {{- if or (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
@@ -50,17 +51,12 @@ data:
       {{- if not .Values.istio_cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
-        # TODO: use proxy image, to speed up stratup
         image: "{{ .Values.global.proxy_init.image }}"
       {{- else }}
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
       {{- end }}
         command:
         - "/usr/local/bin/istio-iptables.sh"
-        - "-p"
-        - "{{ .MeshConfig.ProxyListenPort }}"
-        - "-u"
-        - 1337
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -79,7 +75,16 @@ data:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
-        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
+        env:
+           - name: ENVOY_PORT
+             value: {{ .MeshConfig.ProxyListenPort }}
+           - name: PROXY_UID
+             value: 1337
+          {{- if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` "") }}
+           - name: INBOUND_CAPTURE_PORT
+             value: 15006
+          {{ end }}
+        imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         resources:
           requests:
             cpu: 10m
@@ -111,7 +116,7 @@ data:
       {{- else }}
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
       {{- end }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         resources: {}
         securityContext:
           runAsUser: 0
@@ -121,10 +126,10 @@ data:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
-        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+        image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
       {{- end }}
         ports:
         - containerPort: 15090
@@ -207,6 +212,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+        - --controlPlaneBootstrap=false
+      {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+        - --templateFile=/etc/istio/custom-bootstrap/envoy_bootstrap.json
+      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -220,12 +229,10 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-      {{ if eq .Values.global.proxy.tracer "datadog" }}
         - name: HOST_IP
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-      {{ end }}
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -236,6 +243,8 @@ data:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+          value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
         {{- if .Values.global.network }}
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.network }}"
@@ -254,11 +263,7 @@ data:
         - name: ISTIO_BOOTSTRAP_OVERRIDE
           value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
         {{- end }}
-        {{- if .Values.global.sds.customTokenDirectory }}
-        - name: ISTIO_META_SDS_TOKEN_PATH
-          value: "{{ .Values.global.sds.customTokenDirectory -}}/sdstoken"
-        {{- end }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:
           httpGet:
@@ -269,23 +274,21 @@ data:
           failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
         {{ end -}}
         securityContext:
-          {{- if .Values.global.proxy.privileged }}
+          {{- if (annotation .ObjectMeta `status.sidecar.istio.io/privileged` .Values.global.proxy.privileged) }}
           privileged: true
-          {{- end }}
+          {{ else }}
           {{- if ne .Values.global.proxy.enableCoreDump true }}
           readOnlyRootFilesystem: true
+          {{- end }}
           {{- end }}
           {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
           capabilities:
             add:
             - NET_ADMIN
-          runAsGroup: 1337
           {{ else -}}
-          {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
-          runAsGroup: 1337
-          {{- end }}
           runAsUser: 1337
           {{- end }}
+          runAsGroup: 1337
         resources:
           {{ if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
@@ -315,16 +318,11 @@ data:
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
-        {{- if .Values.global.sds.customTokenDirectory }}
-        - mountPath: "{{ .Values.global.sds.customTokenDirectory -}}"
-          name: custom-sds-token
-          readOnly: true
         {{- end }}
-        {{- else }}
+    
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
-        {{- end }}
         {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
         - mountPath: {{ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}
           name: lightstep-certs
@@ -349,11 +347,6 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if .Values.global.sds.customTokenDirectory }}
-      - name: custom-sds-token
-        secret:
-          secretName: sdstokensecret
-      {{- end }}
       {{- if .Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
@@ -363,7 +356,7 @@ data:
               expirationSeconds: 43200
               audience: {{ .Values.global.trustDomain }}
       {{- end }}
-      {{- else }}
+      {{- end }}
       - name: istio-certs
         secret:
           optional: true
@@ -378,7 +371,6 @@ data:
         {{ toYaml $value | indent 2 }}
         {{ end }}
         {{ end }}
-      {{- end }}
       {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
       - name: lightstep-certs
         secret:
@@ -389,13 +381,14 @@ data:
       dnsConfig:
         searches:
           {{- range .Values.global.podDNSSearchNamespaces }}
-          - {{ . }}
+          - {{ render . }}
           {{- end }}
       {{- end }}
-
+    
 
 ---
 # Source: istio-autoinject/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -406,8 +399,10 @@ metadata:
     release: istio-control-istio-autoinject
     istio: sidecar-injector
 
+
 ---
 # Source: istio-autoinject/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -426,8 +421,10 @@ rules:
   resourceNames: ["istio-sidecar-injector-istio-control"]
   verbs: ["get", "list", "watch", "patch"]
 
+
 ---
 # Source: istio-autoinject/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -445,12 +442,13 @@ subjects:
     name: istio-sidecar-injector-service-account
     namespace: istio-control
 
+
 ---
 # Source: istio-autoinject/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-default
   namespace: istio-control
   labels:
     app: sidecar-injector
@@ -461,23 +459,26 @@ spec:
   - port: 443
   selector:
     istio: sidecar-injector
+    version: default
 
 ---
 # Source: istio-autoinject/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-default
   namespace: istio-control
   labels:
     app: sidecar-injector
     release: istio-control-istio-autoinject
     istio: sidecar-injector
+    version: default
 spec:
   replicas: 1
   selector:
     matchLabels:
       istio: sidecar-injector
+      version: default
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -486,10 +487,11 @@ spec:
     metadata:
       labels:
         app: sidecarInjectorWebhook
+        version: default
         istio: sidecar-injector
       annotations:
         sidecar.istio.io/inject: "false"
-        checksum/config-volume: 0a7842870cea9f1aaddec4a92d4a55e94bd485a875f6223c2f64dc2ac82ddef3
+        checksum/config-volume: 53f8ac3bad55e3c735b17b29ef36fa39b89ec00fd8aa2c53e9872d323e03547b
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
       containers:
@@ -537,23 +539,23 @@ spec:
           resources:
             requests:
               cpu: 10m
-
+            
       volumes:
       - name: config-volume
         configMap:
-          name: istio
+          name: istio-default
       - name: certs
         secret:
           secretName: istio.istio-sidecar-injector-service-account
       - name: inject-config
         configMap:
-          name: istio-sidecar-injector
+          name: istio-sidecar-injector-default
           items:
           - key: config
             path: config
           - key: values
             path: values
-      affinity:
+      affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -585,7 +587,7 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - s390x
+                - s390x      
 
 ---
 # Source: istio-autoinject/templates/mutatingwebhook.yaml
@@ -593,7 +595,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector-istio-control
+  name: istio-sidecar-injector-istio-control-default
   labels:
     app: sidecar-injector
     release: istio-control-istio-autoinject
@@ -601,7 +603,7 @@ webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
-        name: istio-sidecar-injector
+        name: istio-sidecar-injector-default
         namespace: istio-control
         path: "/inject"
       caBundle: ""
@@ -613,6 +615,6 @@ webhooks:
     failurePolicy: Fail
     namespaceSelector:
       matchLabels:
-        istio-env: istio-control
+        istio-env: istio-control-default
 ---
 

--- a/kustomize/istio-control/istio-config.yaml
+++ b/kustomize/istio-control/istio-config.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-galley
+  name: istio-galley-default
   namespace: istio-control
   labels:
     app: galley
@@ -17,6 +17,7 @@ spec:
       app: galley
       release: istio-control-istio-config
       istio: galley
+      version: default
 
 ---
 # Source: istio-config/templates/configmap-envoy.yaml
@@ -24,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: istio-control
-  name: galley-envoy-config
+  name: galley-envoy-config-default
   labels:
     app: galley
     istio: galley
@@ -116,7 +117,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-mesh-galley
+  name: istio-mesh-galley-default
   namespace: istio-control
   labels:
     release: istio-control-istio-config
@@ -125,23 +126,23 @@ data:
 
   mesh: |-
     {}
-
+    
 
 ---
 # Source: istio-config/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-galley-configuration
+  name: istio-galley-configuration-default
   namespace: istio-control
   labels:
     release: istio-control-istio-config
 data:
-  validatingwebhookconfiguration.yaml: |-
+  validatingwebhookconfiguration.yaml: |-    
     apiVersion: admissionregistration.k8s.io/v1beta1
     kind: ValidatingWebhookConfiguration
     metadata:
-      name: istio-galley-istio-control
+      name: istio-galley-istio-control-default
       namespace: istio-control
       labels:
         app: galley
@@ -257,6 +258,7 @@ data:
 
 ---
 # Source: istio-config/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -266,8 +268,10 @@ metadata:
     app: galley
     release: istio-control-istio-config
 
+
 ---
 # Source: istio-config/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -308,6 +312,7 @@ rules:
 
 ---
 # Source: istio-config/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -323,12 +328,13 @@ subjects:
     name: istio-galley-service-account
     namespace: istio-control
 
+
 ---
 # Source: istio-config/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-galley
+  name: istio-galley-default
   namespace: istio-control
   labels:
     app: galley
@@ -346,17 +352,19 @@ spec:
     name: grpc-tls-mcp
   selector:
     istio: galley
+    version: default
 
 ---
 # Source: istio-config/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-galley
+  name: istio-galley-default
   namespace: istio-control
   labels:
     app: galley
     istio: galley
+    version: default
     release: istio-control-istio-config
 spec:
   replicas: 1
@@ -364,6 +372,7 @@ spec:
     matchLabels:
       app: galley
       istio: galley
+      version: default
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -372,6 +381,7 @@ spec:
     metadata:
       labels:
         app: galley
+        version: default
         istio: galley
       annotations:
         sidecar.istio.io/inject: "false"
@@ -433,7 +443,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-
+            
         - name: istio-proxy
           image: "gcr.io/istio-release/proxyv2:master-latest-daily"
           imagePullPolicy: Always
@@ -470,7 +480,7 @@ spec:
             requests:
               cpu: 100m
               memory: 128Mi
-
+            
 
           volumeMounts:
           - name: istio-certs
@@ -485,17 +495,17 @@ spec:
           secretName: istio.istio-galley-service-account
       - name: envoy-config
         configMap:
-          name: galley-envoy-config
+          name: galley-envoy-config-default
       - name: config
         configMap:
-          name: istio-galley-configuration
+          name: istio-galley-configuration-default
       # Different config map from pilot, to allow independent config and rollout.
       # Both are derived from values.yaml.
       - name: mesh-config
         configMap:
-          name: istio-mesh-galley
+          name: istio-mesh-galley-default
 
-      affinity:
+      affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -527,7 +537,7 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - s390x
+                - s390x      
 
 ---
 # Source: istio-config/templates/validatingwebhookconfiguration.yaml.tpl

--- a/kustomize/istio-ingress/istio-ingress.yaml
+++ b/kustomize/istio-ingress/istio-ingress.yaml
@@ -142,7 +142,7 @@ spec:
           - --serviceCluster
           - istio-ingressgateway
           - --zipkinAddress
-          - zipkin.istio-telemetry:9411
+          - zipkin.istio-system:9411
           - --proxyAdminPort
           - "15000"
           - --statusPort
@@ -150,7 +150,7 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          - istio-pilot.istio-control:15011
+          - istio-pilot.istio-system:15011
           readinessProbe:
             failureThreshold: 30
             httpGet:

--- a/kustomize/istio-telemetry/istio-prometheus.yaml
+++ b/kustomize/istio-telemetry/istio-prometheus.yaml
@@ -56,7 +56,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-policy
+          - istio-system
 
 
       relabel_configs:
@@ -81,7 +81,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-control
+          - istio-system
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -93,7 +93,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-control
+          - istio-system
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/kustomize/istio-telemetry/mixer-telemetry.yaml
+++ b/kustomize/istio-telemetry/mixer-telemetry.yaml
@@ -104,11 +104,11 @@ data:
               trusted_ca:
                 filename: /etc/certs/root-cert.pem
               verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-control/sa/istio-galley-service-account
+              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
 
         hosts:
           - socket_address:
-              address: istio-galley.istio-control
+              address: istio-galley.istio-system
               port_value: 15019
 
 
@@ -486,10 +486,10 @@ spec:
           - unix:///sock/mixer.socket
           - --log_output_level=default:info
           - --configStoreURL=mcp://localhost:15019
-          - --configDefaultNamespace=istio-telemetry
+          - --configDefaultNamespace=istio-system
           - --useAdapterCRDs=false
           - --useTemplateCRDs=false
-          - --trace_zipkin_url=http://zipkin.istio-telemetry:9411/api/v1/spans
+          - --trace_zipkin_url=http://zipkin.istio-system:9411/api/v1/spans
         env:
         - name: GODEBUG
           value: "gctrace=1"

--- a/kustomize/micro/discovery.yaml
+++ b/kustomize/micro/discovery.yaml
@@ -4,7 +4,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-micro
   labels:
     app: pilot
@@ -15,6 +15,7 @@ spec:
   selector:
     matchLabels:
       app: pilot
+      version: default
       release: istio-micro-istio-discovery
       istio: pilot
 
@@ -24,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: istio-micro
-  name: pilot-envoy-config
+  name: pilot-envoy-config-default
   labels:
     release: istio-micro-istio-discovery
 data:
@@ -54,10 +55,6 @@ data:
             max_requests: 100000
             max_retries: 3
 
-    # TODO: telemetry using EDS
-    # TODO: other pilots using EDS, load balancing
-    # TODO: galley using EDS
-
       - name: out.galley.15019
         http2_protocol_options: {}
         connect_timeout: 1.000s
@@ -81,11 +78,11 @@ data:
               trusted_ca:
                 filename: /etc/certs/root-cert.pem
               verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-control/sa/istio-galley-service-account
+              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
 
         hosts:
           - socket_address:
-              address: istio-galley.istio-control
+              address: istio-galley-default.istio-system
               port_value: 15019
 
 
@@ -135,19 +132,17 @@ data:
           tls_context:
             require_client_certificate: true
             common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/certs/root-cert.pem
-
               alpn_protocols:
               - h2
 
+              validation_context:
+                trusted_ca:
+                  filename: /etc/certs/root-cert.pem
               tls_certificates:
               - certificate_chain:
                   filename: /etc/certs/cert-chain.pem
                 private_key:
                   filename: /etc/certs/key.pem
-
 
       # Manual 'whitebox' mode
       - name: "local.15019"
@@ -195,7 +190,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio
+  name: istio-default
   namespace: istio-micro
   labels:
     release: istio-micro-istio-discovery
@@ -255,8 +250,8 @@ data:
     reportBatchMaxEntries: 100
     # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
     reportBatchMaxTime: 1s
-    mixerReportServer: istio-telemetry.istio-telemetry.svc.cluster.local:9091
-    mixerCheckServer: istio-policy.istio-policy.svc.cluster.local:9091
+    mixerReportServer: istio-telemetry.istio-system.svc.cluster.local:9091
+    mixerCheckServer: istio-policy.istio-system.svc.cluster.local:9091
 
     disablePolicyChecks: true
 
@@ -265,9 +260,22 @@ data:
     ingressService: "istio-ingressgateway"
     ingressControllerMode: "OFF"
     ingressClass: "istio"
+    # Set expected values when SDS is disabled
     # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get
     # key/cert for mTLS. Use secret-mount files instead of SDS if set to empty.
-    sdsUdsPath: 
+    sdsUdsPath: ""
+    # This flag is used by secret discovery service(SDS).
+    # If set to true(prerequisite: https://kubernetes.io/docs/concepts/storage/volumes/#projected), Istio will inject volumes mount
+    # for k8s service account JWT, so that K8s API server mounts k8s service account JWT to envoy container, which
+    # will be used to generate key/cert eventually. This isn't supported for non-k8s case.
+    enableSdsTokenMount: false
+    # This flag is used by secret discovery service(SDS).
+    # If set to true, envoy will fetch normal k8s service account JWT from '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    # (https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
+    # and pass to sds server, which will be used to request key/cert eventually.
+    # this flag is ignored if enableSdsTokenMount is set.
+    # This isn't supported for non-k8s case.
+    sdsUseK8sSaJwt: false
 
     outboundTrafficPolicy:
       mode: ALLOW_ANY
@@ -306,7 +314,7 @@ data:
       tracing:
         zipkin:
           # Address of the Zipkin collector
-          address: zipkin.istio-telemetry:9411
+          address: zipkin.istio-system:9411
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: NONE
@@ -316,6 +324,7 @@ data:
 
 ---
 # Source: istio-discovery/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -324,9 +333,12 @@ metadata:
   labels:
     app: pilot
     release: istio-micro-istio-discovery
+---
+
 
 ---
 # Source: istio-discovery/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -359,9 +371,12 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
   verbs: ["get", "list", "watch"]
+---
+
 
 ---
 # Source: istio-discovery/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -378,15 +393,17 @@ subjects:
     name: istio-pilot-service-account
     namespace: istio-micro
 
+
 ---
 # Source: istio-discovery/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-micro
   labels:
     app: pilot
+    version: default
     release: istio-micro-istio-discovery
     istio: pilot
 spec:
@@ -401,21 +418,24 @@ spec:
     name: http-monitoring
   selector:
     istio: pilot
+    version: default
 
 ---
 # Source: istio-discovery/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-micro
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
+    version: default
     release: istio-micro-istio-discovery
     istio: pilot
   annotations:
-    checksum/config-volume:  dc8df904a9925f4267d882d8e08bac9b52d7e0a15653e566eed896600d529696
+    checksum/config-volume-envoy:  91cf5466d543424d1bc3ed9227d84dc4da631bfec515f5343773c7bf7606dfc2
+    checksum/config-volume:  9e4bcea6aa41f5583d94b6f6f8ace171c2ca16175cffee17fef3e7d560a18ae7
 spec:
   strategy:
     rollingUpdate:
@@ -428,6 +448,7 @@ spec:
     metadata:
       labels:
         app: pilot
+        version: default
         istio: pilot
       annotations:
         sidecar.istio.io/inject: "false"
@@ -486,13 +507,15 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
-      volumes:
+
+      volumes: # Setting for control-plane-security enabled: certs or sds, custom envoy config
+
+      # Mesh config
       - name: config-volume
         configMap:
-          name: istio
-      - name: pilot-envoy-config
-        configMap:
-          name: pilot-envoy-config
+          name: istio-default
+
+
       affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -529,6 +552,7 @@ spec:
 
 ---
 # Source: istio-discovery/templates/enable-mesh-mtls.yaml
+
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
 # Customer should add similar destination rules for other services that dont' have sidecar.
 apiVersion: networking.istio.io/v1alpha3
@@ -575,13 +599,14 @@ spec:
 
 
 
+
 ---
 # Source: istio-discovery/templates/autoscale.yaml
 
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istio-pilot
+  name: istio-pilot-default
   namespace: istio-micro
   labels:
     app: pilot
@@ -592,7 +617,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: istio-pilot
+    name: istio-pilot-default
   metrics:
   - type: Resource
     resource:

--- a/kustomize/micro/istio-ingress.yaml
+++ b/kustomize/micro/istio-ingress.yaml
@@ -142,7 +142,7 @@ spec:
           - --serviceCluster
           - istio-ingressgateway
           - --zipkinAddress
-          - zipkin.istio-telemetry:9411
+          - zipkin.istio-system:9411
           - --proxyAdminPort
           - "15000"
           - --statusPort

--- a/kustomize/micro/kustomization.yaml
+++ b/kustomize/micro/kustomization.yaml
@@ -4,7 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
   - istio-ingress.yaml
   - discovery.yaml
 

--- a/kustomize/micro/namespace.yaml
+++ b/kustomize/micro/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-micro

--- a/kustomize/sds-agent/sds-agent.yaml
+++ b/kustomize/sds-agent/sds-agent.yaml
@@ -1,0 +1,127 @@
+---
+# Source: nodeagent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-sdsagent
+  namespace: istio-system
+  labels:
+    app: istio-sdsagent
+    release: istio-system-istio-sdsagent
+
+---
+# Source: nodeagent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-sdsagent-istio-system
+  labels:
+    app: istio-sdsagent
+    release: istio-system-istio-sdsagent
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+
+---
+# Source: nodeagent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-sdsagentnt-istio-system
+  labels:
+    app: istio-sdsagent
+    release: istio-system-istio-sdsagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-sdsagent-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istio-sdsagent
+    namespace: istio-system
+
+---
+# Source: nodeagent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: istio-sdsagent
+  namespace: istio-system
+  labels:
+    app: istio-sdsagent
+    istio: sdsagent
+    release: istio-system-istio-sdsagent
+spec:
+  selector:
+    matchLabels:
+      istio: sdsagent
+  template:
+    metadata:
+      labels:
+        app: istio-sdsagent
+        istio: sdsagent
+        release: istio-system-istio-sdsagent
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-sdsagent
+      containers:
+        - name: sdsagent
+          image: "gcr.io/istio-release/node-agent-k8s:master-latest-daily"
+          imagePullPolicy: Always
+          args:
+          volumeMounts:
+            - mountPath: /var/run/sds
+              name: sdsudspath
+          env:
+            - name: CA_PROVIDER
+              value: Citadel
+            - name: CA_ADDR
+              value: istio-citadel:8060
+            - name: "Trust_Domain"
+              value: ""
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      volumes:
+        - name: sdsudspath
+          hostPath:
+            path: /var/run/sds
+      affinity:      
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x      
+  updateStrategy:
+    type: RollingUpdate
+

--- a/security/citadel/templates/clusterrole.yaml
+++ b/security/citadel/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -18,3 +19,4 @@ rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
   verbs: ["create"]
+{{ end }}

--- a/test/demo/k8s.yaml
+++ b/test/demo/k8s.yaml
@@ -4,15 +4,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
+  name: istio-sidecar-injector-default
+  namespace: istio-control
   labels:
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
     app: sidecar-injector
     istio: sidecar-injector
 data:
   values: |-
-    {"configValidation":true,"gateways":{"istio-egressgateway":{"enabled":true,"resources":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"40Mi"}}},"istio-ingressgateway":{"resources":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"40Mi"}}}},"global":{"arch":{"amd64":2,"ppc64le":2,"s390x":2},"configNamespace":"istio-system","configValidation":true,"controlPlaneSecurityEnabled":true,"defaultNodeSelector":{},"defaultPodDisruptionBudget":{"enabled":false},"defaultResources":{"requests":{"cpu":"0m","memory":"1Mi"}},"disablePolicyChecks":false,"enableHelmTest":false,"enableTracing":true,"hub":"gcr.io/istio-release","imagePullPolicy":"Always","imagePullSecrets":null,"istioNamespace":"istio-system","k8sIngress":{"enableHttps":false,"enabled":false,"gatewayName":"ingressgateway"},"localityLbSetting":{},"logAsJson":false,"logging":{"level":"default:info"},"meshExpansion":{"enabled":false,"useILB":false},"meshNetworks":{},"mtls":{"enabled":false},"multiCluster":{"enabled":false},"oneNamespace":false,"outboundTrafficPolicy":{"mode":"ALLOW_ANY"},"policyCheckFailOpen":false,"policyNamespace":"istio-system","priorityClassName":"","prometheusNamespace":"istio-system","proxy":{"accessLogEncoding":"TEXT","accessLogFile":"/dev/stdout","accessLogFormat":"","autoInject":"enabled","clusterDomain":"cluster.local","componentLogLevel":"misc:error","concurrency":2,"dnsRefreshRate":"300s","enableCoreDump":false,"envoyMetricsService":{"enabled":false,"host":null,"port":null},"envoyStatsd":{"enabled":false,"host":null,"port":null},"excludeIPRanges":"","excludeInboundPorts":"","excludeOutboundPorts":"","image":"proxyv2","includeIPRanges":"*","includeInboundPorts":"*","kubevirtInterfaces":"","logLevel":"warning","privileged":false,"readinessFailureThreshold":30,"readinessInitialDelaySeconds":1,"readinessPeriodSeconds":2,"resources":{"limits":{"cpu":"2000m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"40Mi"}},"statusPort":15020,"tracer":"zipkin"},"proxy_init":{"image":"proxy_init"},"sds":{"enabled":false,"udsPath":"","useNormalJwt":false,"useTrustworthyJwt":false},"sidecarInjectorWebhook":{"enabled":true,"rewriteAppHTTPProbe":false},"tag":"master-latest-daily","telemetryNamespace":"istio-system","tracer":{"datadog":{"address":"$(HOST_IP):8126"},"lightstep":{"accessToken":"","address":"","cacertPath":"","secure":true},"zipkin":{"address":""}},"trustDomain":"","useMCP":true},"grafana":{"enabled":true},"istio_cni":{"enabled":false},"kiali":{"createDemoSecret":true,"enabled":true},"mixer":{"adapters":{"stdio":{"enabled":true}},"policy":{"enabled":true,"resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"10m","memory":"100Mi"}}},"telemetry":{"enabled":true,"resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"50m","memory":"100Mi"}}}},"pilot":{"resources":{"limits":{"cpu":"100m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"100Mi"}},"traceSampling":100},"resources":{"requests":{"cpu":"0m","memory":"1Mi"}},"sidecarInjectorWebhook":{"alwaysInjectSelector":[],"enableNamespacesByDefault":true,"image":"sidecar_injector","neverInjectSelector":[],"nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"rewriteAppHTTPProbe":false,"selfSigned":false,"tolerations":[]},"tracing":{"enabled":true}}
+    {"clusterResources":true,"gateways":{"istio-egressgateway":{"enabled":true,"resources":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"40Mi"}}},"istio-ingressgateway":{"resources":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"40Mi"}}}},"global":{"arch":{"amd64":2,"ppc64le":2,"s390x":2},"configNamespace":"istio-control","configValidation":true,"controlPlaneSecurityEnabled":true,"defaultNodeSelector":{},"defaultPodDisruptionBudget":{"enabled":false},"defaultResources":{"requests":{"cpu":"10m"}},"disablePolicyChecks":false,"enableHelmTest":false,"enableTracing":true,"hub":"gcr.io/istio-release","imagePullPolicy":"Always","imagePullSecrets":null,"istioNamespace":"istio-control","k8sIngress":{"enableHttps":false,"enabled":false,"gatewayName":"ingressgateway"},"localityLbSetting":{},"logAsJson":false,"logging":{"level":"default:info"},"meshExpansion":{"enabled":false,"useILB":false},"meshNetworks":{},"mtls":{"enabled":false},"multiCluster":{"enabled":false},"oneNamespace":false,"outboundTrafficPolicy":{"mode":"ALLOW_ANY"},"policyCheckFailOpen":false,"policyNamespace":"istio-system","priorityClassName":"","prometheusNamespace":"istio-system","proxy":{"accessLogEncoding":"TEXT","accessLogFile":"/dev/stdout","accessLogFormat":"","autoInject":"enabled","clusterDomain":"cluster.local","componentLogLevel":"misc:error","concurrency":2,"dnsRefreshRate":"300s","enableCoreDump":false,"envoyMetricsService":{"enabled":false,"host":null,"port":null},"envoyStatsd":{"enabled":false,"host":null,"port":null},"excludeIPRanges":"","excludeInboundPorts":"","excludeOutboundPorts":"","image":"proxyv2","includeIPRanges":"*","includeInboundPorts":"*","kubevirtInterfaces":"","logLevel":"warning","privileged":false,"readinessFailureThreshold":30,"readinessInitialDelaySeconds":1,"readinessPeriodSeconds":2,"resources":{"limits":{"cpu":"2000m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"40Mi"}},"statusPort":15020,"tracer":"zipkin"},"proxy_init":{"image":"proxy_init"},"sds":{"enabled":false,"udsPath":"unix:/var/run/sds/uds_path","useNormalJwt":true,"useTrustworthyJwt":false},"sidecarInjectorWebhook":{"enabled":true,"rewriteAppHTTPProbe":false},"tag":"master-latest-daily","telemetryNamespace":"istio-telemetry","tracer":{"datadog":{"address":"$(HOST_IP):8126"},"lightstep":{"accessToken":"","address":"","cacertPath":"","secure":true},"zipkin":{"address":""}},"trustDomain":"","useMCP":true},"grafana":{"enabled":true},"istio_cni":{"enabled":false},"kiali":{"createDemoSecret":true,"enabled":true},"mixer":{"adapters":{"stdio":{"enabled":true}},"policy":{"enabled":true,"resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"10m","memory":"100Mi"}}},"telemetry":{"enabled":true,"resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"50m","memory":"100Mi"}}}},"pilot":{"resources":{"limits":{"cpu":"100m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"100Mi"}},"traceSampling":100},"sidecarInjectorWebhook":{"alwaysInjectSelector":[],"enableNamespacesByDefault":true,"image":"sidecar_injector","neverInjectSelector":[],"nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"rewriteAppHTTPProbe":false,"selfSigned":false,"tolerations":[]},"tracing":{"enabled":true},"version":"default"}
 
   config: |-
     policy: enabled
@@ -30,17 +30,12 @@ data:
       {{- if not .Values.istio_cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
-        # TODO: use proxy image, to speed up stratup
         image: "{{ .Values.global.proxy_init.image }}"
       {{- else }}
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
       {{- end }}
         command:
         - "/usr/local/bin/istio-iptables.sh"
-        - "-p"
-        - "{{ .MeshConfig.ProxyListenPort }}"
-        - "-u"
-        - 1337
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -59,6 +54,15 @@ data:
         - "-k"
         - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
         {{ end -}}
+        env:
+           - name: ENVOY_PORT
+             value: {{ .MeshConfig.ProxyListenPort }}
+           - name: PROXY_UID
+             value: 1337
+          {{- if contains "*" (annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` "") }}
+           - name: INBOUND_CAPTURE_PORT
+             value: 15006
+          {{ end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         resources:
           requests:
@@ -101,10 +105,10 @@ data:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
-        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+        image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
       {{- end }}
         ports:
         - containerPort: 15090
@@ -187,6 +191,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+        - --controlPlaneBootstrap=false
+      {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+        - --templateFile=/etc/istio/custom-bootstrap/envoy_bootstrap.json
+      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -200,12 +208,10 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-      {{ if eq .Values.global.proxy.tracer "datadog" }}
         - name: HOST_IP
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-      {{ end }}
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:
@@ -216,6 +222,8 @@ data:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+          value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
         {{- if .Values.global.network }}
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.network }}"
@@ -234,10 +242,6 @@ data:
         - name: ISTIO_BOOTSTRAP_OVERRIDE
           value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
         {{- end }}
-        {{- if .Values.global.sds.customTokenDirectory }}
-        - name: ISTIO_META_SDS_TOKEN_PATH
-          value: "{{ .Values.global.sds.customTokenDirectory -}}/sdstoken"
-        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:
@@ -249,23 +253,21 @@ data:
           failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
         {{ end -}}
         securityContext:
-          {{- if .Values.global.proxy.privileged }}
+          {{- if (annotation .ObjectMeta `status.sidecar.istio.io/privileged` .Values.global.proxy.privileged) }}
           privileged: true
-          {{- end }}
+          {{ else }}
           {{- if ne .Values.global.proxy.enableCoreDump true }}
           readOnlyRootFilesystem: true
+          {{- end }}
           {{- end }}
           {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
           capabilities:
             add:
             - NET_ADMIN
-          runAsGroup: 1337
           {{ else -}}
-          {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
-          runAsGroup: 1337
-          {{- end }}
           runAsUser: 1337
           {{- end }}
+          runAsGroup: 1337
         resources:
           {{ if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
@@ -295,16 +297,11 @@ data:
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
-        {{- if .Values.global.sds.customTokenDirectory }}
-        - mountPath: "{{ .Values.global.sds.customTokenDirectory -}}"
-          name: custom-sds-token
-          readOnly: true
         {{- end }}
-        {{- else }}
+    
         - mountPath: /etc/certs/
           name: istio-certs
           readOnly: true
-        {{- end }}
         {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
         - mountPath: {{ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}
           name: lightstep-certs
@@ -329,11 +326,6 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if .Values.global.sds.customTokenDirectory }}
-      - name: custom-sds-token
-        secret:
-          secretName: sdstokensecret
-      {{- end }}
       {{- if .Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
@@ -343,7 +335,7 @@ data:
               expirationSeconds: 43200
               audience: {{ .Values.global.trustDomain }}
       {{- end }}
-      {{- else }}
+      {{- end }}
       - name: istio-certs
         secret:
           optional: true
@@ -358,7 +350,6 @@ data:
         {{ toYaml $value | indent 2 }}
         {{ end }}
         {{ end }}
-      {{- end }}
       {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
       - name: lightstep-certs
         secret:
@@ -376,25 +367,28 @@ data:
 
 ---
 # Source: istio-autoinject/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-sidecar-injector-service-account
-  namespace: istio-system
+  namespace: istio-control
   labels:
     app: sidecar-injector
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
     istio: sidecar-injector
+
 
 ---
 # Source: istio-autoinject/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-sidecar-injector-istio-system
+  name: istio-sidecar-injector-istio-control
   labels:
     app: sidecar-injector
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
     istio: sidecar-injector
 rules:
 - apiGroups: [""]
@@ -403,61 +397,67 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  resourceNames: ["istio-sidecar-injector-istio-system"]
+  resourceNames: ["istio-sidecar-injector-istio-control"]
   verbs: ["get", "list", "watch", "patch"]
+
 
 ---
 # Source: istio-autoinject/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-sidecar-injector-admin-role-binding-istio-system
+  name: istio-sidecar-injector-admin-role-binding-istio-control
   labels:
     app: sidecar-injector
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
     istio: sidecar-injector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-sidecar-injector-istio-system
+  name: istio-sidecar-injector-istio-control
 subjects:
   - kind: ServiceAccount
     name: istio-sidecar-injector-service-account
-    namespace: istio-system
+    namespace: istio-control
+
 
 ---
 # Source: istio-autoinject/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
+  name: istio-sidecar-injector-default
+  namespace: istio-control
   labels:
     app: sidecar-injector
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
     istio: sidecar-injector
 spec:
   ports:
   - port: 443
   selector:
     istio: sidecar-injector
+    version: default
 
 ---
 # Source: istio-autoinject/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
+  name: istio-sidecar-injector-default
+  namespace: istio-control
   labels:
     app: sidecar-injector
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
     istio: sidecar-injector
+    version: default
 spec:
   replicas: 1
   selector:
     matchLabels:
       istio: sidecar-injector
+      version: default
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -466,13 +466,11 @@ spec:
     metadata:
       labels:
         app: sidecarInjectorWebhook
+        version: default
         istio: sidecar-injector
-        heritage: Tiller
-        release: istio
-        chart: sidecarInjectorWebhook
       annotations:
         sidecar.istio.io/inject: "false"
-        checksum/config-volume: 0a7842870cea9f1aaddec4a92d4a55e94bd485a875f6223c2f64dc2ac82ddef3
+        checksum/config-volume: 53f8ac3bad55e3c735b17b29ef36fa39b89ec00fd8aa2c53e9872d323e03547b
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
       containers:
@@ -487,7 +485,7 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
-            - --webhookConfigName=istio-sidecar-injector-istio-system
+            - --webhookConfigName=istio-sidecar-injector-istio-control
             - --log_output_level=debug
           volumeMounts:
           - name: config-volume
@@ -519,19 +517,18 @@ spec:
             periodSeconds: 4
           resources:
             requests:
-              cpu: 0m
-              memory: 1Mi
+              cpu: 10m
             
       volumes:
       - name: config-volume
         configMap:
-          name: istio
+          name: istio-default
       - name: certs
         secret:
           secretName: istio.istio-sidecar-injector-service-account
       - name: inject-config
         configMap:
-          name: istio-sidecar-injector
+          name: istio-sidecar-injector-default
           items:
           - key: config
             path: config
@@ -577,16 +574,16 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector-istio-system
+  name: istio-sidecar-injector-istio-control-default
   labels:
     app: sidecar-injector
-    release: istio-system-istio-autoinject
+    release: istio-control-istio-autoinject
 webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
-        name: istio-sidecar-injector
-        namespace: istio-system
+        name: istio-sidecar-injector-default
+        namespace: istio-control
         path: "/inject"
       caBundle: ""
     rules:
@@ -600,7 +597,7 @@ webhooks:
       - key: name
         operator: NotIn
         values:
-        - istio-system
+        - istio-control
       - key: istio-injection
         operator: NotIn
         values:
@@ -614,184 +611,16 @@ webhooks:
 
 
 ---
-# Source: citadel/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-citadel11-service-account
-  namespace: istio-system
-
-  labels:
-    release: istio-system-istio-citadel
-
-
----
-# Source: citadel/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: istio-citadel11-istio-system
-  labels:
-    app: citadel
-    release: istio-system-istio-citadel
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create", "get", "update"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list", "update", "delete"]
-- apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["authentication.k8s.io"]
-  resources: ["tokenreviews"]
-  verbs: ["create"]
-
----
-# Source: citadel/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: istio-citadel11-istio-system
-  labels:
-    release: istio-system-istio-citadel
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-citadel11-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-citadel11-service-account
-    namespace: istio-system
-
----
-# Source: citadel/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-citadel11
-  namespace: istio-system
-  labels:
-    app: citadel
-    istio: citadel
-    release: istio-system-istio-citadel
-
-spec:
-  ports:
-    - name: grpc-citadel
-      port: 8060
-      targetPort: 8060
-      protocol: TCP
-    - name: http-monitoring
-      port: 15014
-  selector:
-    app: citadel
-
----
-# Source: citadel/templates/deployment.yaml
-# istio CA watching all namespaces
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istio-citadel11
-  namespace: istio-system
-  labels:
-    app: citadel
-    istio: citadel
-    release: istio-system-istio-citadel
-
-spec:
-  selector:
-    matchLabels:
-      istio: citadel
-  replicas: 1
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  template:
-    metadata:
-      labels:
-        app: citadel
-        istio: citadel
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      serviceAccountName: istio-citadel11-service-account
-      containers:
-        - name: citadel
-          image: "gcr.io/istio-release/citadel:master-latest-daily"
-          imagePullPolicy: Always
-          args:
-            - --append-dns-names=true
-            - --grpc-port=8060
-          # global.tag may contain something like "release-1.1-latest-daily". Assume >1.2 if we cannot extract semver version.
-            - --grpc-host-identities=citadel
-            - --citadel-storage-namespace=istio-system
-            - --custom-dns-names=istio-galley-service-account.istio-config:istio-galley.istio-config.svc,istio-galley-service-account.istio-control:istio-galley.istio-control.svc,istio-galley-service-account.istio-control-master:istio-galley.istio-control-master.svc,istio-galley-service-account.istio-master:istio-galley.istio-master.svc,istio-galley-service-account.istio-pilot11:istio-galley.istio-pilot11.svc,istio-sidecar-injector-service-account.istio-control:istio-sidecar-injector.istio-control.svc,istio-sidecar-injector-service-account.istio-control-master:istio-sidecar-injector.istio-control-master.svc,istio-sidecar-injector-service-account.istio-master:istio-sidecar-injector.istio-master.svc,istio-sidecar-injector-service-account.istio-pilot11:istio-sidecar-injector.istio-pilot11.svc,istio-sidecar-injector-service-account.istio-remote:istio-sidecar-injector.istio-remote.svc,
-            - --self-signed-ca=true
-            - --trust-domain=cluster.local
-          livenessProbe:
-            httpGet:
-              path: /version
-              port: 15014
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          resources:
-            requests:
-              cpu: 0m
-              memory: 1Mi
-            
-      affinity:      
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x      
-
----
-# Source: citadel/templates/poddisruptionbudget.yaml
-
-
----
 # Source: istio-config/templates/configmap-envoy.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: istio-system
-  name: galley-envoy-config
+  namespace: istio-control
+  name: galley-envoy-config-default
   labels:
     app: galley
     istio: galley
-    release: istio-system-istio-config
+    release: istio-control-istio-config
 data:
   envoy.yaml.tmpl: |-
     admin:
@@ -879,10 +708,10 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-mesh-galley
-  namespace: istio-system
+  name: istio-mesh-galley-default
+  namespace: istio-control
   labels:
-    release: istio-system-istio-config
+    release: istio-control-istio-config
 data:
 
 
@@ -895,27 +724,27 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-galley-configuration
-  namespace: istio-system
+  name: istio-galley-configuration-default
+  namespace: istio-control
   labels:
-    release: istio-system-istio-config
+    release: istio-control-istio-config
 data:
   validatingwebhookconfiguration.yaml: |-    
     apiVersion: admissionregistration.k8s.io/v1beta1
     kind: ValidatingWebhookConfiguration
     metadata:
-      name: istio-galley-istio-system
-      namespace: istio-system
+      name: istio-galley-istio-control-default
+      namespace: istio-control
       labels:
         app: galley
-        release: istio-system-istio-config
+        release: istio-control-istio-config
         istio: galley
     webhooks:
       - name: pilot.validation.istio.io
         clientConfig:
           service:
             name: istio-galley
-            namespace: istio-system
+            namespace: istio-control
             path: "/admitpilot"
           caBundle: ""
         rules:
@@ -969,7 +798,7 @@ data:
         clientConfig:
           service:
             name: istio-galley
-            namespace: istio-system
+            namespace: istio-control
             path: "/admitmixer"
           caBundle: ""
         rules:
@@ -1020,23 +849,26 @@ data:
 
 ---
 # Source: istio-config/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-galley-service-account
-  namespace: istio-system
+  namespace: istio-control
   labels:
     app: galley
-    release: istio-system-istio-config
+    release: istio-control-istio-config
+
 
 ---
 # Source: istio-config/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-galley-istio-system
+  name: istio-galley-istio-control
   labels:
-    release: istio-system-istio-config
+    release: istio-control-istio-config
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingwebhookconfigurations"]
@@ -1071,32 +903,34 @@ rules:
 
 ---
 # Source: istio-config/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-galley-admin-role-binding-istio-system
+  name: istio-galley-admin-role-binding-istio-control
   labels:
-    release: istio-system-istio-config
+    release: istio-control-istio-config
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-galley-istio-system
+  name: istio-galley-istio-control
 subjects:
   - kind: ServiceAccount
     name: istio-galley-service-account
-    namespace: istio-system
+    namespace: istio-control
+
 
 ---
 # Source: istio-config/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-galley
-  namespace: istio-system
+  name: istio-galley-default
+  namespace: istio-control
   labels:
     app: galley
     istio: galley
-    release: istio-system-istio-config
+    release: istio-control-istio-config
 spec:
   ports:
   - port: 443
@@ -1109,24 +943,27 @@ spec:
     name: grpc-tls-mcp
   selector:
     istio: galley
+    version: default
 
 ---
 # Source: istio-config/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-galley
-  namespace: istio-system
+  name: istio-galley-default
+  namespace: istio-control
   labels:
     app: galley
     istio: galley
-    release: istio-system-istio-config
+    version: default
+    release: istio-control-istio-config
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: galley
       istio: galley
+      version: default
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -1135,10 +972,8 @@ spec:
     metadata:
       labels:
         app: galley
+        version: default
         istio: galley
-        heritage: Tiller
-        release: istio
-        chart: galley
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -1163,7 +998,7 @@ spec:
           - --insecure=true
           - --enable-validation=true
           - --enable-server=true
-          - --deployment-namespace=istio-system
+          - --deployment-namespace=istio-control
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort=15014
@@ -1251,15 +1086,15 @@ spec:
           secretName: istio.istio-galley-service-account
       - name: envoy-config
         configMap:
-          name: galley-envoy-config
+          name: galley-envoy-config-default
       - name: config
         configMap:
-          name: istio-galley-configuration
+          name: istio-galley-configuration-default
       # Different config map from pilot, to allow independent config and rollout.
       # Both are derived from values.yaml.
       - name: mesh-config
         configMap:
-          name: istio-mesh-galley
+          name: istio-mesh-galley-default
 
       affinity:      
         nodeAffinity:
@@ -1308,10 +1143,10 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: istio-system
-  name: pilot-envoy-config
+  namespace: istio-control
+  name: pilot-envoy-config-default
   labels:
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 data:
   envoy.yaml.tmpl: |-
     admin:
@@ -1339,10 +1174,6 @@ data:
             max_requests: 100000
             max_retries: 3
 
-    # TODO: telemetry using EDS
-    # TODO: other pilots using EDS, load balancing
-    # TODO: galley using EDS
-
       - name: out.galley.15019
         http2_protocol_options: {}
         connect_timeout: 1.000s
@@ -1366,11 +1197,11 @@ data:
               trusted_ca:
                 filename: /etc/certs/root-cert.pem
               verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
+              - spiffe://cluster.local/ns/istio-control/sa/istio-galley-service-account
 
         hosts:
           - socket_address:
-              address: istio-galley.istio-system
+              address: istio-galley-default.istio-control
               port_value: 15019
 
 
@@ -1420,19 +1251,17 @@ data:
           tls_context:
             require_client_certificate: true
             common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/certs/root-cert.pem
-
               alpn_protocols:
               - h2
 
+              validation_context:
+                trusted_ca:
+                  filename: /etc/certs/root-cert.pem
               tls_certificates:
               - certificate_chain:
                   filename: /etc/certs/cert-chain.pem
                 private_key:
                   filename: /etc/certs/key.pem
-
 
       # Manual 'whitebox' mode
       - name: "local.15019"
@@ -1480,10 +1309,10 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio
-  namespace: istio-system
+  name: istio-default
+  namespace: istio-control
   labels:
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 data:
 
   meshNetworks: |-
@@ -1542,7 +1371,7 @@ data:
     reportBatchMaxEntries: 100
     # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
     reportBatchMaxTime: 1s
-    mixerReportServer: istio-telemetry.istio-system.svc.cluster.local:15004
+    mixerReportServer: istio-telemetry.istio-telemetry.svc.cluster.local:15004
     mixerCheckServer: istio-policy.istio-system.svc.cluster.local:15004
 
     disablePolicyChecks: true
@@ -1608,34 +1437,38 @@ data:
       tracing:
         zipkin:
           # Address of the Zipkin collector
-          address: zipkin.istio-system:9411
+          address: zipkin.istio-telemetry:9411
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: MUTUAL_TLS
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot.istio-system:15011
+      discoveryAddress: istio-pilot.istio-control:15011
 
 ---
 # Source: istio-discovery/templates/serviceaccount.yaml
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-pilot-service-account
-  namespace: istio-system
+  namespace: istio-control
   labels:
     app: pilot
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
+---
+
 
 ---
 # Source: istio-discovery/templates/clusterrole.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-pilot-istio-system
+  name: istio-pilot-istio-control
   labels:
     app: pilot
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 rules:
 - apiGroups: ["config.istio.io"]
   resources: ["*"]
@@ -1661,35 +1494,40 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints", "pods", "services", "namespaces", "nodes", "secrets"]
   verbs: ["get", "list", "watch"]
+---
+
 
 ---
 # Source: istio-discovery/templates/clusterrolebinding.yaml
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-pilot-istio-system
+  name: istio-pilot-istio-control
   labels:
     app: pilot
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-pilot-istio-system
+  name: istio-pilot-istio-control
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: istio-system
+    namespace: istio-control
+
 
 ---
 # Source: istio-discovery/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
-  namespace: istio-system
+  name: istio-pilot-default
+  namespace: istio-control
   labels:
     app: pilot
-    release: istio-system-istio-discovery
+    version: default
+    release: istio-control-istio-discovery
     istio: pilot
 spec:
   ports:
@@ -1703,21 +1541,24 @@ spec:
     name: http-monitoring
   selector:
     istio: pilot
+    version: default
 
 ---
 # Source: istio-discovery/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-pilot
-  namespace: istio-system
+  name: istio-pilot-default
+  namespace: istio-control
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
-    release: istio-system-istio-discovery
+    version: default
+    release: istio-control-istio-discovery
     istio: pilot
   annotations:
-    checksum/config-volume:  315ec933516c5037b3dae7746ac9f0362fedc5d38150b289ec2294a651d65cf6
+    checksum/config-volume-envoy:  4170f99c02a5af355b5e949c704dfabad090ef33ee6abe467f81be4475d4b7f9
+    checksum/config-volume:  7dc2643c486bb545ff63a8e2a787274de670d46e2a195577a3262f0d879fb527
 spec:
   strategy:
     rollingUpdate:
@@ -1730,10 +1571,8 @@ spec:
     metadata:
       labels:
         app: pilot
+        version: default
         istio: pilot
-        heritage: Tiller
-        release: istio
-        chart: pilot
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/config-volume-envoy: c5ca26039d50542de673a4a578803a5d69f4c85fcd033f9c4a672ffb7cd4052f
@@ -1837,19 +1676,28 @@ spec:
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
+          # Config map with the pilot envoy config
           - name: pilot-envoy-config
             mountPath: /var/lib/envoy
+
       volumes:
-      - name: config-volume
-        configMap:
-          name: istio
-      - name: pilot-envoy-config
-        configMap:
-          name: pilot-envoy-config
+
       - name: istio-certs
         secret:
           secretName: istio.istio-pilot-service-account
           optional: true
+
+      # Custom envoy config, for sidecar
+      - name: pilot-envoy-config
+        configMap:
+          name: pilot-envoy-config-default # Setting for control-plane-security enabled: certs or sds, custom envoy config
+
+      # Mesh config
+      - name: config-volume
+        configMap:
+          name: istio-default
+
+
       affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1886,15 +1734,16 @@ spec:
 
 ---
 # Source: istio-discovery/templates/enable-mesh-mtls.yaml
+
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
 # Customer should add similar destination rules for other services that dont' have sidecar.
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "api-server"
-  namespace: istio-system
+  namespace: istio-control
   labels:
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 spec:
   host: "kubernetes.default.svc.cluster.local"
   trafficPolicy:
@@ -1909,9 +1758,9 @@ apiVersion: "authentication.istio.io/v1alpha1"
 kind: "MeshPolicy"
 metadata:
   name: "default"
-  namespace: istio-system
+  namespace: istio-control
   labels:
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 spec:
   peers:
   - mtls:
@@ -1921,14 +1770,15 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "default"
-  namespace: istio-system
+  namespace: istio-control
   labels:
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 spec:
   host: "*.local"
   trafficPolicy:
     tls:
       mode: DISABLE
+
 
 
 
@@ -1938,18 +1788,18 @@ spec:
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istio-pilot
-  namespace: istio-system
+  name: istio-pilot-default
+  namespace: istio-control
   labels:
     app: pilot
-    release: istio-system-istio-discovery
+    release: istio-control-istio-discovery
 spec:
   maxReplicas: 5
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: istio-pilot
+    name: istio-pilot-default
   metrics:
   - type: Resource
     resource:
@@ -1968,11 +1818,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-egressgateway
-  namespace: istio-system
+  namespace: istio-egress
   annotations:
   labels:
     app: istio-egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
   type: ClusterIP
   selector:
@@ -1997,11 +1847,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-egressgateway
-  namespace: istio-system
+  namespace: istio-egress
   labels:
     app: istio-egressgateway
     istio: egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
   selector:
     matchLabels:
@@ -2012,9 +1862,6 @@ spec:
       labels:
         app: istio-egressgateway
         istio: egressgateway
-        heritage: Tiller
-        release: istio
-        chart: gateways
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -2046,7 +1893,7 @@ spec:
           - --serviceCluster
           - istio-egressgateway
           - --zipkinAddress
-          - zipkin.istio-system:9411
+          - zipkin.istio-telemetry:9411
           - --proxyAdminPort
           - "15000"
           - --statusPort
@@ -2054,7 +1901,7 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          - istio-pilot.istio-system:15011
+          - istio-pilot.istio-control:15011
           readinessProbe:
             failureThreshold: 30
             httpGet:
@@ -2174,10 +2021,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-multicluster-egressgateway
-  namespace: istio-system
+  namespace: istio-egress
   labels:
     app: istio-egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
   selector:
     istio: egressgateway
@@ -2194,10 +2041,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: istio-multicluster-egressgateway
-  namespace: istio-system 
+  namespace: istio-egress 
   labels:
     app: istio-egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
   gateways:
   - istio-multicluster-egressgateway
@@ -2219,10 +2066,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: istio-multicluster-egressgateway
-  namespace: istio-system
+  namespace: istio-egress
   labels:
     app: istio-egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
    workloadLabels:
      istio: egressgateway
@@ -2239,10 +2086,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: istio-multicluster-destinationrule
-  namespace: istio-system
+  namespace: istio-egress
   labels:
     app: istio-egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
   host: "*.global"
   trafficPolicy:
@@ -2257,10 +2104,10 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: egressgateway
-  namespace: istio-system
+  namespace: istio-egress
   labels:
     app: istio-egressgateway
-    release: istio-system-istio-egress
+    release: istio-egress-istio-egress
 spec:
   maxReplicas: 5
   minReplicas: 1
@@ -2290,10 +2137,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-galley-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   galley-dashboard.json: '{
@@ -4121,10 +3968,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-istio-mesh-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   istio-mesh-dashboard.json: '{
@@ -5086,10 +4933,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-istio-performance-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   istio-performance-dashboard.json: '{
@@ -6920,10 +6767,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-istio-service-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   istio-service-dashboard.json: '{
@@ -9533,10 +9380,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-istio-workload-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   istio-workload-dashboard.json: '{
@@ -11848,10 +11695,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-mixer-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   mixer-dashboard.json: '{
@@ -13668,10 +13515,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana-configuration-dashboards-pilot-dashboard
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   pilot-dashboard.json: '{
@@ -15472,10 +15319,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-grafana
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     istio: grafana
 data:
   datasources.yaml: |-
@@ -15507,11 +15354,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: istio-system
+  namespace: istio-telemetry
   annotations:
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   type: ClusterIP
   ports:
@@ -15528,10 +15375,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   replicas: 1
   selector:
@@ -15573,8 +15420,7 @@ spec:
             value: /data/grafana
           resources:
             requests:
-              cpu: 0m
-              memory: 1Mi
+              cpu: 10m
             
           volumeMounts:
           - name: data
@@ -15680,9 +15526,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: grafana
-  namespace: istio-system
+  namespace: istio-telemetry
 spec:
-  host: grafana.istio-system
+  host: grafana.istio-telemetry
   trafficPolicy:
     tls:
       mode: DISABLE
@@ -15693,10 +15539,10 @@ apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
   name: grafana-ports-mtls-disabled
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: grafana
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   targets:
   - name: grafana
@@ -15717,10 +15563,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-ingressgateway-service-account
-  namespace: istio-system
+  namespace: istio-ingress
   labels:
     app: istio-ingressgateway
-    release: istio-system-istio-ingress
+    release: istio-ingress-istio-ingress
 ---
 # Source: istio-ingress/templates/service.yaml
 
@@ -15728,11 +15574,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingressgateway
-  namespace: istio-system
+  namespace: istio-ingress
   annotations:
   labels:
     app: istio-ingressgateway
-    release: istio-system-istio-ingress
+    release: istio-ingress-istio-ingress
 spec:
   type: LoadBalancer
   selector:
@@ -15780,11 +15626,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingressgateway
-  namespace: istio-system
+  namespace: istio-ingress
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    release: istio-system-istio-ingress
+    release: istio-ingress-istio-ingress
 spec:
   selector:
     matchLabels:
@@ -15795,9 +15641,6 @@ spec:
       labels:
         app: istio-ingressgateway
         istio: ingressgateway
-        heritage: Tiller
-        release: istio
-        chart: gateways
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -15838,7 +15681,7 @@ spec:
           - --serviceCluster
           - istio-ingressgateway
           - --zipkinAddress
-          - zipkin.istio-system:9411
+          - zipkin.istio-telemetry:9411
           - --proxyAdminPort
           - "15000"
           - --statusPort
@@ -15846,7 +15689,7 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          - istio-pilot.istio-system:15011
+          - istio-pilot.istio-control:15011
           readinessProbe:
             failureThreshold: 30
             httpGet:
@@ -15968,9 +15811,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: ingressgateway
-  namespace: istio-system
+  namespace: istio-ingress
   labels:
-    release: istio-system-istio-ingress
+    release: istio-ingress-istio-ingress
 spec:
   selector:
     istio: ingressgateway
@@ -15991,10 +15834,10 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: ingressgateway
-  namespace: istio-system
+  namespace: istio-ingress
   labels:
     app: istio-ingressgateway
-    release: istio-system-istio-ingress
+    release: istio-ingress-istio-ingress
 spec:
   maxReplicas: 5
   minReplicas: 1
@@ -16015,9 +15858,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
   name: default
-  namespace: istio-system
+  namespace: istio-ingress
   labels:
-    release: istio-system-istio-ingress
+    release: istio-ingress-istio-ingress
 spec:
   egress:
     - hosts:
@@ -16071,15 +15914,620 @@ spec:
 
 
 ---
+# Source: istio-policy/templates/poddisruptionbudget.yaml
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: istio-policy
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+    istio: mixer
+    istio-mixer-type: policy
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: istio-policy
+      release: istio-policy-istio-policy
+      istio: mixer
+      istio-mixer-type: policy
+
+---
+# Source: istio-policy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-policy-service-account
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+
+---
+# Source: istio-policy/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-policy
+  labels:
+    release: istio-policy-istio-policy
+    app: istio-policy
+rules:
+- apiGroups: ["config.istio.io"] # istio CRD watcher
+  resources: ["*"]
+  verbs: ["create", "get", "list", "watch", "patch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets", "replicationcontrollers"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Source: istio-policy/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-policy-admin-role-binding-istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-policy
+subjects:
+  - kind: ServiceAccount
+    name: istio-policy-service-account
+    namespace: istio-policy
+
+---
+# Source: istio-policy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-policy
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    istio: mixer
+    release: istio-policy-istio-policy
+spec:
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-policy-monitoring
+    port: 15014
+  selector:
+    app: istio-policy
+---
+
+
+---
+# Source: istio-policy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-policy
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    istio: mixer
+    release: istio-policy-istio-policy
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: istio-policy
+      istio: mixer
+      istio-mixer-type: policy
+  template:
+    metadata:
+      labels:
+        app: istio-policy
+        istio: mixer
+        istio-mixer-type: policy
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-policy-service-account
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-policy-service-account
+          optional: true
+      - name: uds-socket
+        emptyDir: {}
+      - name: policy-adapter-secret
+        secret:
+          secretName: policy-adapter-secret
+          optional: true
+      affinity:      
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x      
+      containers:
+      - name: mixer
+        image: "gcr.io/istio-release/mixer:master-latest-daily"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 15014
+        - containerPort: 42422
+        args:
+          - --monitoringPort=15014
+          - --address
+          - unix:///sock/mixer.socket
+          - --log_output_level=default:info
+          - --configStoreURL=mcps://istio-galley.istio-system.svc:15019
+          - --configDefaultNamespace=istio-system
+          - --useAdapterCRDs=false
+          - --useTemplateCRDs=false
+          - --trace_zipkin_url=http://zipkin.istio-system:9411/api/v1/spans
+        env:
+        - name: GODEBUG
+          value: "gctrace=1"
+        resources:
+          requests:
+            cpu: 10m
+          
+        volumeMounts:
+        - name: istio-certs
+          mountPath: /etc/certs
+          readOnly: true
+        - name: uds-socket
+          mountPath: /sock
+        - name: policy-adapter-secret
+          mountPath: /var/run/secrets/istio.io/policy/adapter
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /version
+            port: 15014
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      - name: istio-proxy
+        image: "gcr.io/istio-release/proxyv2:master-latest-daily"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9091
+        - containerPort: 15004
+        - containerPort: 15090
+          protocol: TCP
+          name: http-envoy-prom
+        args:
+        - proxy
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --serviceCluster
+        - istio-policy
+        - --templateFile
+        - /etc/istio/proxy/envoy_policy.yaml.tmpl
+        - --controlPlaneAuthPolicy
+        - MUTUAL_TLS
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          
+        volumeMounts:
+        - name: istio-certs
+          mountPath: /etc/certs
+          readOnly: true
+        - name: uds-socket
+          mountPath: /sock
+
+
+---
+# Source: istio-policy/templates/autoscale.yaml
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: istio-policy
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+    maxReplicas: 5
+    minReplicas: 1
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: istio-policy
+    metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
+---
+
+---
+# Source: istio-policy/templates/config.yaml
+apiVersion: "config.istio.io/v1alpha2"
+kind: attributemanifest
+metadata:
+  name: istioproxy
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  attributes:
+    origin.ip:
+      valueType: IP_ADDRESS
+    origin.uid:
+      valueType: STRING
+    origin.user:
+      valueType: STRING
+    request.headers:
+      valueType: STRING_MAP
+    request.id:
+      valueType: STRING
+    request.host:
+      valueType: STRING
+    request.method:
+      valueType: STRING
+    request.path:
+      valueType: STRING
+    request.url_path:
+      valueType: STRING
+    request.query_params:
+      valueType: STRING_MAP
+    request.reason:
+      valueType: STRING
+    request.referer:
+      valueType: STRING
+    request.scheme:
+      valueType: STRING
+    request.total_size:
+      valueType: INT64
+    request.size:
+      valueType: INT64
+    request.time:
+      valueType: TIMESTAMP
+    request.useragent:
+      valueType: STRING
+    response.code:
+      valueType: INT64
+    response.duration:
+      valueType: DURATION
+    response.headers:
+      valueType: STRING_MAP
+    response.total_size:
+      valueType: INT64
+    response.size:
+      valueType: INT64
+    response.time:
+      valueType: TIMESTAMP
+    response.grpc_status:
+      valueType: STRING
+    response.grpc_message:
+      valueType: STRING
+    source.uid:
+      valueType: STRING
+    source.user: # DEPRECATED
+      valueType: STRING
+    source.principal:
+      valueType: STRING
+    destination.uid:
+      valueType: STRING
+    destination.principal:
+      valueType: STRING
+    destination.port:
+      valueType: INT64
+    connection.event:
+      valueType: STRING
+    connection.id:
+      valueType: STRING
+    connection.received.bytes:
+      valueType: INT64
+    connection.received.bytes_total:
+      valueType: INT64
+    connection.sent.bytes:
+      valueType: INT64
+    connection.sent.bytes_total:
+      valueType: INT64
+    connection.duration:
+      valueType: DURATION
+    connection.mtls:
+      valueType: BOOL
+    connection.requested_server_name:
+      valueType: STRING
+    context.protocol:
+      valueType: STRING
+    context.proxy_error_code:
+      valueType: STRING
+    context.timestamp:
+      valueType: TIMESTAMP
+    context.time:
+      valueType: TIMESTAMP
+    # Deprecated, kept for compatibility
+    context.reporter.local:
+      valueType: BOOL
+    context.reporter.kind:
+      valueType: STRING
+    context.reporter.uid:
+      valueType: STRING
+    api.service:
+      valueType: STRING
+    api.version:
+      valueType: STRING
+    api.operation:
+      valueType: STRING
+    api.protocol:
+      valueType: STRING
+    request.auth.principal:
+      valueType: STRING
+    request.auth.audiences:
+      valueType: STRING
+    request.auth.presenter:
+      valueType: STRING
+    request.auth.claims:
+      valueType: STRING_MAP
+    request.auth.raw_claims:
+      valueType: STRING
+    request.api_key:
+      valueType: STRING
+    rbac.permissive.response_code:
+      valueType: STRING
+    rbac.permissive.effective_policy_id:
+      valueType: STRING
+    check.error_code:
+      valueType: INT64
+    check.error_message:
+      valueType: STRING
+    check.cache_hit:
+      valueType: BOOL
+    quota.cache_hit:
+      valueType: BOOL
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: attributemanifest
+metadata:
+  name: kubernetes
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  attributes:
+    source.ip:
+      valueType: IP_ADDRESS
+    source.labels:
+      valueType: STRING_MAP
+    source.metadata:
+      valueType: STRING_MAP
+    source.name:
+      valueType: STRING
+    source.namespace:
+      valueType: STRING
+    source.owner:
+      valueType: STRING
+    source.serviceAccount:
+      valueType: STRING
+    source.services:
+      valueType: STRING
+    source.workload.uid:
+      valueType: STRING
+    source.workload.name:
+      valueType: STRING
+    source.workload.namespace:
+      valueType: STRING
+    destination.ip:
+      valueType: IP_ADDRESS
+    destination.labels:
+      valueType: STRING_MAP
+    destination.metadata:
+      valueType: STRING_MAP
+    destination.owner:
+      valueType: STRING
+    destination.name:
+      valueType: STRING
+    destination.container.name:
+      valueType: STRING
+    destination.namespace:
+      valueType: STRING
+    destination.service.uid:
+      valueType: STRING
+    destination.service.name:
+      valueType: STRING
+    destination.service.namespace:
+      valueType: STRING
+    destination.service.host:
+      valueType: STRING
+    destination.serviceAccount:
+      valueType: STRING
+    destination.workload.uid:
+      valueType: STRING
+    destination.workload.name:
+      valueType: STRING
+    destination.workload.namespace:
+      valueType: STRING
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: handler
+metadata:
+  name: kubernetesenv
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  compiledAdapter: kubernetesenv
+  params:
+    # when running from mixer root, use the following config after adding a
+    # symbolic link to a kubernetes config file via:
+    #
+    # $ ln -s ~/.kube/config mixer/adapter/kubernetes/kubeconfig
+    #
+    # kubeconfig_path: "mixer/adapter/kubernetes/kubeconfig"
+
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: kubeattrgenrulerule
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  actions:
+  - handler: kubernetesenv
+    instances:
+    - attributes
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: tcpkubeattrgenrulerule
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  match: context.protocol == "tcp"
+  actions:
+  - handler: kubernetesenv
+    instances:
+    - attributes
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: attributes
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  compiledTemplate: kubernetes
+  params:
+    # Pass the required attribute data to the adapter
+    source_uid: source.uid | ""
+    source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
+    destination_uid: destination.uid | ""
+    destination_port: destination.port | 0
+  attributeBindings:
+    # Fill the new attributes from the adapter produced output.
+    # $out refers to an instance of OutputTemplate message
+    source.ip: $out.source_pod_ip | ip("0.0.0.0")
+    source.uid: $out.source_pod_uid | "unknown"
+    source.labels: $out.source_labels | emptyStringMap()
+    source.name: $out.source_pod_name | "unknown"
+    source.namespace: $out.source_namespace | "default"
+    source.owner: $out.source_owner | "unknown"
+    source.serviceAccount: $out.source_service_account_name | "unknown"
+    source.workload.uid: $out.source_workload_uid | "unknown"
+    source.workload.name: $out.source_workload_name | "unknown"
+    source.workload.namespace: $out.source_workload_namespace | "unknown"
+    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+    destination.uid: $out.destination_pod_uid | "unknown"
+    destination.labels: $out.destination_labels | emptyStringMap()
+    destination.name: $out.destination_pod_name | "unknown"
+    destination.container.name: $out.destination_container_name | "unknown"
+    destination.namespace: $out.destination_namespace | "default"
+    destination.owner: $out.destination_owner | "unknown"
+    destination.serviceAccount: $out.destination_service_account_name | "unknown"
+    destination.workload.uid: $out.destination_workload_uid | "unknown"
+    destination.workload.name: $out.destination_workload_name | "unknown"
+    destination.workload.namespace: $out.destination_workload_namespace | "unknown"
+---
+# Configuration needed by Mixer.
+# Mixer cluster is delivered via CDS
+# Specify mixer cluster settings
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: istio-policy
+  namespace: istio-policy
+  labels:
+    app: istio-policy
+    release: istio-policy-istio-policy
+spec:
+  host: istio-policy.istio-policy.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 15004
+      tls:
+        mode: ISTIO_MUTUAL
+    connectionPool:
+      http:
+        http2MaxRequests: 10000
+        maxRequestsPerConnection: 10000
+
+---
 # Source: prometheus/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: prometheus
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 data:
   prometheus.yml: |-
     global:
@@ -16093,7 +16541,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio-telemetry
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
@@ -16141,7 +16589,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio-telemetry
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -16153,7 +16601,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio-control
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -16165,7 +16613,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio-control
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -16177,7 +16625,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio-telemetry
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -16355,20 +16803,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: prometheus
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 
 ---
 # Source: prometheus/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-istio-system
+  name: prometheus-istio-telemetry
   labels:
     app: prometheus
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 rules:
 - apiGroups: [""]
   resources:
@@ -16390,18 +16838,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-istio-system
+  name: prometheus-istio-telemetry
   labels:
     app: prometheus
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-istio-system
+  name: prometheus-istio-telemetry
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: istio-system
+  namespace: istio-telemetry
 
 ---
 # Source: prometheus/templates/service.yaml
@@ -16409,12 +16857,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio-telemetry
   annotations:
     prometheus.io/scrape: 'true'
   labels:
     app: prometheus
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   selector:
     app: prometheus
@@ -16430,10 +16878,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: prometheus
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   replicas: 1
   selector:
@@ -16443,7 +16891,7 @@ spec:
     metadata:
       labels:
         app: prometheus
-        release: istio-system-istio-telemetry
+        release: istio-telemetry-istio-telemetry
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -16468,8 +16916,7 @@ spec:
               port: 9090
           resources:
             requests:
-              cpu: 0m
-              memory: 1Mi
+              cpu: 10m
             
           volumeMounts:
           - name: config-volume
@@ -16524,9 +16971,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: prometheys
-  namespace: istio-system
+  namespace: istio-telemetry
 spec:
-  host: prometheus.istio-system
+  host: prometheus.istio-telemetry
   trafficPolicy:
     tls:
       mode: DISABLE
@@ -16535,9 +16982,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: prometheus-full
-  namespace: istio-system
+  namespace: istio-telemetry
 spec:
-  host: prometheus.istio-system.svc.cluster.local
+  host: prometheus.istio-telemetry.svc.cluster.local
   trafficPolicy:
     tls:
       mode: DISABLE
@@ -16554,10 +17001,10 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: istio-system
+  namespace: istio-telemetry
   name: telemetry-envoy-config
   labels:
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 data:
   # Explicitly defined - moved from istio/istio/pilot/docker.
   envoy.yaml.tmpl: |-
@@ -16633,11 +17080,11 @@ data:
               trusted_ca:
                 filename: /etc/certs/root-cert.pem
               verify_subject_alt_name:
-              - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
+              - spiffe://cluster.local/ns/istio-control/sa/istio-galley-service-account
 
         hosts:
           - socket_address:
-              address: istio-galley.istio-system
+              address: istio-galley.istio-control
               port_value: 15019
 
 
@@ -16681,9 +17128,9 @@ data:
               generate_request_id: true
               http_filters:
               - config:
-                  default_destination_service: istio-telemetry.istio-system.svc.cluster.local
+                  default_destination_service: istio-telemetry.istio-telemetry.svc.cluster.local
                   service_configs:
-                    istio-telemetry.istio-system.svc.cluster.local:
+                    istio-telemetry.istio-telemetry.svc.cluster.local:
                       disable_check_calls: true
     {{- if .DisableReportCalls }}
                       disable_report_calls: true
@@ -16691,17 +17138,17 @@ data:
                       mixer_attributes:
                         attributes:
                           destination.service.host:
-                            string_value: istio-telemetry.istio-system.svc.cluster.local
+                            string_value: istio-telemetry.istio-telemetry.svc.cluster.local
                           destination.service.uid:
-                            string_value: istio://istio-system/services/istio-telemetry
+                            string_value: istio://istio-telemetry/services/istio-telemetry
                           destination.service.name:
                             string_value: istio-telemetry
                           destination.service.namespace:
-                            string_value: istio-system
+                            string_value: istio-telemetry
                           destination.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
+                            string_value: kubernetes://{{ .PodName }}.istio-telemetry
                           destination.namespace:
-                            string_value: istio-system
+                            string_value: istio-telemetry
                           destination.ip:
                             bytes_value: {{ .PodIP }}
                           destination.port:
@@ -16709,7 +17156,7 @@ data:
                           context.reporter.kind:
                             string_value: inbound
                           context.reporter.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
+                            string_value: kubernetes://{{ .PodName }}.istio-telemetry
                   transport:
                     check_cluster: mixer_check_server
                     report_cluster: inbound_9092
@@ -16720,7 +17167,7 @@ data:
                 virtual_hosts:
                 - domains:
                   - '*'
-                  name: istio-telemetry.istio-system.svc.cluster.local
+                  name: istio-telemetry.istio-telemetry.svc.cluster.local
                   routes:
                   - decorator:
                       operation: Report
@@ -16759,9 +17206,9 @@ data:
               generate_request_id: true
               http_filters:
               - config:
-                  default_destination_service: istio-telemetry.istio-system.svc.cluster.local
+                  default_destination_service: istio-telemetry.istio-telemetry.svc.cluster.local
                   service_configs:
-                    istio-telemetry.istio-system.svc.cluster.local:
+                    istio-telemetry.istio-telemetry.svc.cluster.local:
                       disable_check_calls: true
     {{- if .DisableReportCalls }}
                       disable_report_calls: true
@@ -16769,17 +17216,17 @@ data:
                       mixer_attributes:
                         attributes:
                           destination.service.host:
-                            string_value: istio-telemetry.istio-system.svc.cluster.local
+                            string_value: istio-telemetry.istio-telemetry.svc.cluster.local
                           destination.service.uid:
-                            string_value: istio://istio-system/services/istio-telemetry
+                            string_value: istio://istio-telemetry/services/istio-telemetry
                           destination.service.name:
                             string_value: istio-telemetry
                           destination.service.namespace:
-                            string_value: istio-system
+                            string_value: istio-telemetry
                           destination.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
+                            string_value: kubernetes://{{ .PodName }}.istio-telemetry
                           destination.namespace:
-                            string_value: istio-system
+                            string_value: istio-telemetry
                           destination.ip:
                             bytes_value: {{ .PodIP }}
                           destination.port:
@@ -16787,7 +17234,7 @@ data:
                           context.reporter.kind:
                             string_value: inbound
                           context.reporter.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
+                            string_value: kubernetes://{{ .PodName }}.istio-telemetry
                   transport:
                     check_cluster: mixer_check_server
                     report_cluster: inbound_9092
@@ -16798,7 +17245,7 @@ data:
                 virtual_hosts:
                 - domains:
                   - '*'
-                  name: istio-telemetry.istio-system.svc.cluster.local
+                  name: istio-telemetry.istio-telemetry.svc.cluster.local
                   routes:
                   - decorator:
                       operation: Report
@@ -16854,20 +17301,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-mixer-service-account
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 
 ---
 # Source: mixer-telemetry/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-mixer-istio-system
+  name: istio-mixer-istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
   resources: ["*"]
@@ -16886,18 +17333,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-mixer-admin-role-binding-istio-system
+  name: istio-mixer-admin-role-binding-istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-mixer-istio-system
+  name: istio-mixer-istio-telemetry
 subjects:
   - kind: ServiceAccount
     name: istio-mixer-service-account
-    namespace: istio-system
+    namespace: istio-telemetry
 
 ---
 # Source: mixer-telemetry/templates/service.yaml
@@ -16905,11 +17352,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-telemetry
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
     istio: mixer
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   ports:
   - name: grpc-mixer
@@ -16929,11 +17376,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-telemetry
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
     istio: mixer
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   replicas: 1
   strategy:
@@ -17015,10 +17462,10 @@ spec:
           - unix:///sock/mixer.socket
           - --log_output_level=default:info
           - --configStoreURL=mcp://localhost:15019
-          - --configDefaultNamespace=istio-system
+          - --configDefaultNamespace=istio-telemetry
           - --useAdapterCRDs=false
           - --useTemplateCRDs=false
-          - --trace_zipkin_url=http://zipkin.istio-system:9411/api/v1/spans
+          - --trace_zipkin_url=http://zipkin.istio-telemetry:9411/api/v1/spans
         env:
         - name: GODEBUG
           value: "gctrace=1"
@@ -17107,9 +17554,9 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: istio-telemetry
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
     app: istio-telemetry
 spec:
     maxReplicas: 5
@@ -17139,10 +17586,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest
 metadata:
   name: istioproxy
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   attributes:
     origin.ip:
@@ -17278,10 +17725,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest
 metadata:
   name: kubernetes
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   attributes:
     source.ip:
@@ -17341,10 +17788,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: stdio
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledAdapter: stdio
   params:
@@ -17354,10 +17801,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: accesslog
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: logentry
   params:
@@ -17411,10 +17858,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: tcpaccesslog
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: logentry
   params:
@@ -17453,10 +17900,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: stdio
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
   actions:
@@ -17468,10 +17915,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: stdiotcp
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: context.protocol == "tcp"
   actions:
@@ -17483,10 +17930,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: requestcount
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17518,10 +17965,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: requestduration
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17553,10 +18000,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: requestsize
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17588,10 +18035,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: responsesize
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17623,10 +18070,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: tcpbytesent
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17654,10 +18101,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: tcpbytereceived
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17685,10 +18132,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: tcpconnectionsopened
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17716,10 +18163,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: tcpconnectionsclosed
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: metric
   params:
@@ -17747,10 +18194,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledAdapter: prometheus
   params:
@@ -17758,7 +18205,7 @@ spec:
       metricsExpiryDuration: "10m"
     metrics:
     - name: requests_total
-      instance_name: requestcount.instance.istio-system
+      instance_name: requestcount.instance.istio-telemetry
       kind: COUNTER
       label_names:
       - reporter
@@ -17782,7 +18229,7 @@ spec:
       - permissive_response_policyid
       - connection_security_policy
     - name: request_duration_seconds
-      instance_name: requestduration.instance.istio-system
+      instance_name: requestduration.instance.istio-telemetry
       kind: DISTRIBUTION
       label_names:
       - reporter
@@ -17809,7 +18256,7 @@ spec:
         explicit_buckets:
           bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
     - name: request_bytes
-      instance_name: requestsize.instance.istio-system
+      instance_name: requestsize.instance.istio-telemetry
       kind: DISTRIBUTION
       label_names:
       - reporter
@@ -17838,7 +18285,7 @@ spec:
           scale: 1
           growthFactor: 10
     - name: response_bytes
-      instance_name: responsesize.instance.istio-system
+      instance_name: responsesize.instance.istio-telemetry
       kind: DISTRIBUTION
       label_names:
       - reporter
@@ -17867,7 +18314,7 @@ spec:
           scale: 1
           growthFactor: 10
     - name: tcp_sent_bytes_total
-      instance_name: tcpbytesent.instance.istio-system
+      instance_name: tcpbytesent.instance.istio-telemetry
       kind: COUNTER
       label_names:
       - reporter
@@ -17887,7 +18334,7 @@ spec:
       - connection_security_policy
       - response_flags
     - name: tcp_received_bytes_total
-      instance_name: tcpbytereceived.instance.istio-system
+      instance_name: tcpbytereceived.instance.istio-telemetry
       kind: COUNTER
       label_names:
       - reporter
@@ -17907,7 +18354,7 @@ spec:
       - connection_security_policy
       - response_flags
     - name: tcp_connections_opened_total
-      instance_name: tcpconnectionsopened.instance.istio-system
+      instance_name: tcpconnectionsopened.instance.istio-telemetry
       kind: COUNTER
       label_names:
       - reporter
@@ -17927,7 +18374,7 @@ spec:
       - connection_security_policy
       - response_flags
     - name: tcp_connections_closed_total
-      instance_name: tcpconnectionsclosed.instance.istio-system
+      instance_name: tcpconnectionsclosed.instance.istio-telemetry
       kind: COUNTER
       label_names:
       - reporter
@@ -17951,10 +18398,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: promhttp
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
@@ -17969,10 +18416,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: promtcp
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: context.protocol == "tcp"
   actions:
@@ -17985,10 +18432,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: promtcpconnectionopen
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
   actions:
@@ -18000,10 +18447,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: promtcpconnectionclosed
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
   actions:
@@ -18015,10 +18462,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: kubernetesenv
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledAdapter: kubernetesenv
   params:
@@ -18034,10 +18481,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: kubeattrgenrulerule
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   actions:
   - handler: kubernetesenv
@@ -18048,10 +18495,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: tcpkubeattrgenrulerule
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   match: context.protocol == "tcp"
   actions:
@@ -18063,10 +18510,10 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
   name: attributes
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
   compiledTemplate: kubernetes
   params:
@@ -18104,12 +18551,12 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: istio-telemetry
-  namespace: istio-system
+  namespace: istio-telemetry
   labels:
     app: istio-telemetry
-    release: istio-system-istio-telemetry
+    release: istio-telemetry-istio-telemetry
 spec:
-  host: istio-telemetry.istio-system.svc.cluster.local
+  host: istio-telemetry.istio-telemetry.svc.cluster.local
   trafficPolicy:
     portLevelSettings:
     - port:

--- a/test/install.mk
+++ b/test/install.mk
@@ -66,6 +66,7 @@ run-build-demo: dep
 	bin/iop ${ISTIO_SYSTEM_NS} istio-telemetry ${BASE}/istio-telemetry/grafana -t ${DEMO_OPTS} > ${OUT}/release/demo/istio-grafana.yaml
 	# bin/iop ${ISTIO_SYSTEM_NS} istio-policy ${BASE}/istio-policy -t > ${OUT}/release/demo/istio-policy.yaml
 	cat ${OUT}/release/demo/*.yaml > test/demo/k8s.yaml
+	cat ${OUT}/release/demo/*.yaml > kustomize/demo/k8s.yaml
 
 
 run-lint:

--- a/test/sds/fortio.yaml
+++ b/test/sds/fortio.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fortio
+spec:
+  ports:
+  - port: 8080
+    name: http-echo
+  - port: 8079
+    name: grpc-ping
+  selector:
+    app: fortio
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fortio
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/logLevel: "TRACE"
+        sidecar.istio.io/enableCoreDump: "true"
+        sidecar.istio.io/privileged: "true"
+        sidecar.istio.io/debug: "true"
+        sidecar.istio.io/componentLogLevel: "config:trace,http2:trace,init:trace,grpc:trace,upstream:trace"
+
+        # Test it with the 1.2.0 image, want to check if SDS can be upgraded with the rel.
+        sidecar.istio.io/proxyImage: istio/proxyv2:1.2.0
+
+        # SDS for control plane in progress
+        sidecar.istio.io/discoveryAddress: "istio-pilot.istio-sds:15011"
+
+        # To iterate faster and debug - use custom template (break glass)
+        sidecar.istio.io/bootstrapOverride: "sds"
+
+        # Override container ports
+        traffic.sidecar.istio.io/includeInboundPorts: "*"
+
+      labels:
+        app: fortio
+        version: v1
+    spec:
+      containers:
+      - name: fortio
+        image: costinm/fortio:latest
+#        ports:
+#         - containerPort: 8080
+#         - containerPort: 8079
+        args:
+          - server
+

--- a/test/sds/sds.mk
+++ b/test/sds/sds.mk
@@ -1,0 +1,110 @@
+
+
+# Target to run SDS graceful upgrade tests
+test-sds:
+	$(MAKE) maybe-clean maybe-prepare sync
+	$(MAKE) kind-run TARGET="run-sds-tests"
+
+# Will install basic Istio, and in a separate ns the SDS-enabled control plane and test app
+run-sds-tests: install-crds install-base install-sds-cp install-sds-app
+
+# Not working with kind default setup: --set global.sds.useTrustworthyJwt=true
+#
+
+# The test is generating an injector with self-signed certificate - this will not work with kustomize (helm generates
+# a cert).
+# TODO: investigate if kustomize can do the same
+
+# Test for installation of the test-mode SDS and test app.
+install-sds-cp: run-build-multi
+	bin/iop istio-system istio-citadel ${BASE}/security/citadel  ${IOP_OPTS}  ${INSTALL_OPTS} \
+	  --set global.sds.enabled=true
+	# SDS agent runs in istio-system, next to citadel. Both are security-critical.
+	kubectl apply -k kustomize/sds-agent
+	# Equivalent with:
+	# bin/iop istio-system istio-sds-agent ${BASE}/security/nodeagent ${IOP_OPTS}  ${INSTALL_OPTS}
+
+	kubectl create ns istio-sds || true
+	kubectl label ns istio-sds istio-injection=disabled --overwrite
+
+	bin/iop istio-sds istio-discovery ${BASE}/istio-control/istio-discovery  ${IOP_OPTS}  ${INSTALL_OPTS} \
+	  --set pilot.useMCP=false \
+	  --set pilot.telemetry.enabled=false \
+	  --set global.sds.enabled=true
+
+	bin/iop istio-sds istio-autoinject ${BASE}/istio-control/istio-autoinject ${IOP_OPTS} ${INSTALL_OPTS} \
+		 --set global.sds.enabled=true \
+		 --set sidecarInjectorWebhook.selfSigned=true \
+		 --set global.istioNamespace=istio-sds
+
+	kubectl wait deployments istio-pilot istio-sidecar-injector -n istio-sds --for=condition=available --timeout=${WAIT_TIMEOUT}
+
+install-sds-app:
+	kubectl create ns fortio-sds || true
+	kubectl label ns fortio-sds istio-env=istio-sds --overwrite
+	kubectl -n fortio-sds apply -k test/sds
+	kubectl wait deployments fortio  -n fortio-sds --for=condition=available --timeout=${WAIT_TIMEOUT}
+	# TODO: curl to verify fortio works and check sds stats
+
+# small tests for SDS config options - mainly checks the templates render with common sds-related
+# options.
+sds-unit:
+	# Minimal - no MCP, use default k8s tokens
+	${IOP} istio-sds istio-discovery ${BASE}/istio-control/istio-discovery -t \
+	   --set pilot.useMCP=false --set global.sds.enabled=true  > ${TMPDIR}/pilot-sds1.yaml
+
+	# Use MCP, new tokens, override trustDomain
+	${IOP} istio-sds istio-discovery ${BASE}/istio-control/istio-discovery -t \
+	   --set global.sds.enabled=true \
+	   --set global.sds.useTrustworthyJwt=true \
+	   --set global.trustDomain=example.com \
+	    > ${TMPDIR}/pilot-sds-jwt-trustdomain.yaml
+
+	# Verify manual inject works
+	istioctl kube-inject -f test/sds/fortio.yaml -n fortio-sds --meshConfigFile test/simple/mesh.yaml \
+	  --valuesFile test/simple/values.yaml \
+      --injectConfigFile istio-control/istio-autoinject/files/injection-template.yaml >  ${TMPDIR}/fortio-injected.yaml
+
+# SDS tests use telemetry lite.
+# To visualize: use env.sh and 'kindFwd' helper to forward prom/grafana
+install-sds-telemetry:
+	$(MAKE) install-prometheus
+	# TODO: add a small test to verify grafana has whatever we need to add. Right now it's empty of SDS info, which is a bug
+	$(MAKE) install-grafana
+
+sds-shell-app:
+	$(MAKE) pod-shell NS=fortio-sds LABEL="app=fortio" C=istio-proxy CMD=bash
+
+sds-shell-pilot:
+	$(MAKE) pod-shell NS=istio-sds LABEL="istio=pilot" C=istio-proxy CMD=bash
+
+sds-logs-pilot:
+	$(MAKE) pod-logs NS=istio-sds LABEL="istio=pilot" C=discovery
+
+sds-logs-pilotenvoy:
+	$(MAKE) pod-logs NS=istio-sds LABEL="istio=pilot" C=istio-proxy
+
+sds-kill:
+	$(MAKE) pod-kill NS=fortio-sds LABEL="app=fortio"
+
+sds-logs-app:
+	$(MAKE) pod-logs NS=fortio-sds LABEL="app=fortio" C=istio-proxy
+
+sds-logs-agent:
+	$(MAKE) pod-logs NS=istio-system LABEL="app=istio-nodeagent" C=nodeagent
+
+sds-dump:
+	$(MAKE) pod-shell NS=fortio-sds LABEL="app=fortio" C=istio-proxy CMD="curl localhost:15000/certs"
+	$(MAKE) pod-shell NS=fortio-sds LABEL="app=fortio" C=istio-proxy CMD="curl localhost:15000/config_dump"
+    #"curl localhost:15000/logging?http2=trace -X POST"
+
+# Generic debug target to exec into one of the containers, using LABEL, NS, C, CMD
+pod-shell:
+	kubectl -n ${NS} exec -it ${shell kubectl --namespace=${NS} get -l ${LABEL} pod -o=jsonpath='{.items[0].metadata.name}'} -c ${C} -- ${CMD}
+
+pod-kill:
+	kubectl -n ${NS} delete pod ${shell kubectl --namespace=${NS} get -l ${LABEL} pod -o=jsonpath='{.items[0].metadata.name}'}
+
+pod-logs:
+	kubectl -n ${NS} logs ${shell kubectl --namespace=${NS} get -l ${LABEL} pod -o=jsonpath='{.items[0].metadata.name}'} -c ${C} -f
+


### PR DESCRIPTION
This is the start of supporting multiple isolated versions of Istio in same namespace, and removing the need to create a new namespace to isolate.

For 1.3 we are reducing the scope to pilot + injector, eventually other components will be added.

The mechanism is similar with knative - the config is bundled with the deployment. 

The main trick is separating cluster-wide resources from the deployment+config and adding version. 