### PR TITLE
fix ingress-gateway rolebinding labels

### DIFF
--- a/gateways/istio-ingress/templates/rolebindings.yaml
+++ b/gateways/istio-ingress/templates/rolebindings.yaml
@@ -4,7 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istio-ingressgateway-sds
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
kubectl apply --prune -l release=<release name> is unable to create rolebinding for ingress-gateway. This PR fixes the issue by adding a release label to the rolebinding. 

Signed-off-by: Jon Yucel <jon.yucel@getcruise.com>