### PR TITLE
Mixer should use local useMCP var and Mixer's sidecar should be configurable

### DIFF
--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -116,7 +116,7 @@ data:
     sdsUseK8sSaJwt: false
     {{- end }}
 
-    {{- if .Values.global.useMCP }}
+    {{- if .Values.pilot.useMCP }}
     config_sources:
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     - address: localhost:15019

--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -116,7 +116,7 @@ data:
     sdsUseK8sSaJwt: false
     {{- end }}
 
-    {{- if .Values.pilot.useMCP }}
+    {{- if .Values.global.useMCP }}
     config_sources:
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     - address: localhost:15019

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -94,8 +94,6 @@ pilot:
     # Will not define mixerCheckServer and mixerReportServer
     enabled: false
 
-  useMCP: true
-
 ## Mixer settings
 mixer:
   telemetry:

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -94,6 +94,8 @@ pilot:
     # Will not define mixerCheckServer and mixerReportServer
     enabled: false
 
+  useMCP: true
+
 ## Mixer settings
 mixer:
   telemetry:

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -94,6 +94,7 @@ pilot:
     # Will not define mixerCheckServer and mixerReportServer
     enabled: false
 
+  # Indicate if Galley is enabled to send MCP queries
   useMCP: true
 
 ## Mixer settings

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
 {{- if .Values.global.logAsJson }}
           - --log_as_json
 {{- end }}
-{{- if .Values.mixer.telemetry.useMCP }}
+{{- if .Values.global.useMCP }}
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcp://localhost:15019
     {{- else }}
@@ -122,7 +122,7 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
         volumeMounts:
-{{- if .Values.mixer.telemetry.useMCP }}
+{{- if .Values.global.useMCP }}
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
 {{- if .Values.global.logAsJson }}
           - --log_as_json
 {{- end }}
-{{- if .Values.global.useMCP }}
+{{- if .Values.mixer.telemetry.useMCP }}
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcp://localhost:15019
     {{- else }}
@@ -122,7 +122,7 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
         volumeMounts:
-{{- if .Values.global.useMCP }}
+{{- if .Values.mixer.telemetry.useMCP }}
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
 {{- if .Values.global.logAsJson }}
           - --log_as_json
 {{- end }}
-{{- if .Values.global.useMCP }}
+{{- if .Values.mixer.telemetry.useMCP }}
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcp://localhost:15019
     {{- else }}
@@ -122,7 +122,7 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
         volumeMounts:
-{{- if .Values.global.useMCP }}
+{{- if .Values.mixer.telemetry.useMCP }}
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
@@ -138,7 +138,7 @@ spec:
             port: 15014
           initialDelaySeconds: 5
           periodSeconds: 5
-
+{{- if .Values.global.controlPlaneSecurityEnabled }}
       - name: istio-proxy
 {{- if contains "/" .Values.global.proxy.image }}
         image: "{{ .Values.global.proxy.image }}"
@@ -212,4 +212,5 @@ spec:
         {{- end }}
         - name: uds-socket
           mountPath: /sock
+{{- end }}
 ---

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -27,6 +27,7 @@ mixer:
         cpu: 4800m
         memory: 4G
 
+    # Indicate if Galley is enabled to send MCP queries
     useMCP: true
 
   env:

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -27,6 +27,8 @@ mixer:
         cpu: 4800m
         memory: 4G
 
+    useMCP: true
+
   env:
     GODEBUG: gctrace=1
     # max procs should be ceil(cpu limit + 1)

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -27,8 +27,6 @@ mixer:
         cpu: 4800m
         memory: 4G
 
-    useMCP: true
-
   env:
     GODEBUG: gctrace=1
     # max procs should be ceil(cpu limit + 1)


### PR DESCRIPTION
This PR addresses 2 issues:
- Mixer is currently hard coded to run with a sidecar. This should be controllable similarly to Pilot.
- Mixer is current using `global.useMCP`, but Pilot is using `pilot.useMCP`. We should be consistent, so I introduced a `mixer.telemetry.useMCP`.