### PR TITLE
disable scrap endpoints that require certificate when prometheus.security=false

### DIFF
--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -114,6 +114,7 @@ spec:
       action: replace
       targetLabel: pod_name
 ---
+{{- if .Values.prometheus-operator.security.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -169,6 +170,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_name]
       action: replace
       targetLabel: pod_name
+{{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -215,6 +217,7 @@ spec:
       action: replace
       targetLabel: pod_name
 ---
+{{- if .Values.prometheus-operator.security.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -270,6 +273,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_name]
       action: replace
       targetLabel: pod_name
+{{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/istio-telemetry/prometheus-operator/values.yaml
+++ b/istio-telemetry/prometheus-operator/values.yaml
@@ -18,6 +18,10 @@ prometheus:
       enabled: false
       port: 32090
 
+  # Indicate if Citadel is enabled, i.e., whether its generated certificates are available
+  security:
+    enabled: true
+
   nodeSelector: {}
   tolerations: []
 

--- a/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/istio-telemetry/prometheus/templates/configmap.yaml
@@ -239,6 +239,7 @@ data:
         action: replace
         target_label: pod_name
 
+{{- if .Values.prometheus.security.enabled }}
     - job_name: 'kubernetes-pods-istio-secure'
       scheme: https
       tls_config:
@@ -277,3 +278,4 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
+{{- end }}

--- a/istio-telemetry/prometheus/values.yaml
+++ b/istio-telemetry/prometheus/values.yaml
@@ -32,7 +32,7 @@ prometheus:
 #      enabled: false
 #      port: 32090
 
-  # Indicate if Citadel is enabled, i.e., its generated certificates are available
+  # Indicate if Citadel is enabled, i.e., whether its generated certificates are available
   security:
     enabled: true
 

--- a/istio-telemetry/prometheus/values.yaml
+++ b/istio-telemetry/prometheus/values.yaml
@@ -32,6 +32,7 @@ prometheus:
 #      enabled: false
 #      port: 32090
 
+  # Indicate if Citadel is enabled, i.e., its generated certificates are available
   security:
     enabled: true
 


### PR DESCRIPTION
When prometheus.secure is set to false, prometheus deployment will not mount from the istio.default secret. However, it will still try to scrap from the `kubernetes-pods-istio-secure` endpoint that requires the certificate mounted from istio.default secret, resulting in unnecessary error messages in prometheus pods. This disables the scrap endpoint when prometheus.security=false