### PR TITLE
Expose the option --enable-reconcileWebhookConfiguration

### DIFF
--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
           - --validation-port=9443
           - --enable-server=true
           - --deployment-namespace={{ .Release.Namespace }}
+          - --enable-reconcileWebhookConfiguration={{ .Values.galley.enableReconcileWebhookConfiguration }}
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort=15014

--- a/istio-control/istio-config/values.yaml
+++ b/istio-control/istio-config/values.yaml
@@ -36,3 +36,6 @@ galley:
   # “security” and value “S1”.
   podAntiAffinityLabelSelector: []
   podAntiAffinityTermLabelSelector: []
+
+  # Enable reconcile validatingwebhookconfiguration
+  enableReconcileWebhookConfiguration: true


### PR DESCRIPTION
Expose the option --enable-reconcileWebhookConfiguration, which allows a user to turn on/off Galley managing its own webhookconfiguration.
Related PR: https://github.com/istio/istio/pull/16118

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/8736

Design document: https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure