### PR TITLE
Add the option --enableManageWebhookConfig

### DIFF
--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --port=9443
-            - --enableSidecarInjectorToManageWebhookConfig={{ .Values.sidecarInjectorWebhook.enableSidecarInjectorToManageWebhookConfig }}
+            - --enableReconcileWebhookConfiguration={{ .Values.sidecarInjectorWebhook.enableReconcileWebhookConfiguration }}
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
                   {{- if eq .Release.Namespace "istio-system"}}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --port=9443
-            - --enableManageWebhookConfig={{ .Values.sidecarInjectorWebhook.enableManageWebhookConfig }}
+            - --enableSidecarInjectorToManageWebhookConfig={{ .Values.sidecarInjectorWebhook.enableSidecarInjectorToManageWebhookConfig }}
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
                   {{- if eq .Release.Namespace "istio-system"}}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --port=9443
+            - --enableManageWebhookConfig={{ .Values.sidecarInjectorWebhook.enableManageWebhookConfig }}
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
                   {{- if eq .Release.Namespace "istio-system"}}

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -61,7 +61,7 @@ sidecarInjectorWebhook:
   # When it is false, Sidecar Injector does not configure its k8s mutatingwebhookconfiguration.
   # If another component configures the k8s mutatingwebhookconfiguration for Sidecar Injector,
   # this parameter should be set as false.
-  enableSidecarInjectorToManageWebhookConfig: true
+  enableReconcileWebhookConfiguration: true
 
 # If set, no iptable init will be added. It assumes CNI is installed.
 # TODO: rename to 'enableIptables' or add 'interceptionMode: CNI'

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -56,6 +56,9 @@ sidecarInjectorWebhook:
   neverInjectSelector: []
   alwaysInjectSelector: []
 
+  # Enable managing webhookconfiguration
+  enableManageWebhookConfig: true
+
 # If set, no iptable init will be added. It assumes CNI is installed.
 # TODO: rename to 'enableIptables' or add 'interceptionMode: CNI'
 istio_cni:

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -56,8 +56,12 @@ sidecarInjectorWebhook:
   neverInjectSelector: []
   alwaysInjectSelector: []
 
-  # Enable managing webhookconfiguration
-  enableManageWebhookConfig: true
+  # Enable Sidecar Injector to configure its k8s mutatingwebhookconfiguration,
+  # When it is true, Sidecar Injector configures its k8s mutatingwebhookconfiguration.
+  # When it is false, Sidecar Injector does not configure its k8s mutatingwebhookconfiguration.
+  # If another component configures the k8s mutatingwebhookconfiguration for Sidecar Injector,
+  # this parameter should be set as false.
+  enableSidecarInjectorToManageWebhookConfig: true
 
 # If set, no iptable init will be added. It assumes CNI is installed.
 # TODO: rename to 'enableIptables' or add 'interceptionMode: CNI'


### PR DESCRIPTION
Add the option --enableManageWebhookConfig to allow turning on/off Sidecar-Injector managing its own webhookconfiguration.

Related PR: istio/istio#16121

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/8736

Design document: https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure