### PR TITLE
fix wrong helm variable name

### DIFF
--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -114,7 +114,7 @@ spec:
       action: replace
       targetLabel: pod_name
 ---
-{{- if .Values.prometheus-operator.security.enabled }}
+{{- if .Values.prometheus.security.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Incorrectly named `prometheus.security.enabled` to `prometheus-operator.security.enabled`.