### PR TITLE
Expose the option --append-dns-names

### DIFF
--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             {{- if .Values.global.sds.enabled }}
             - --sds-enabled=true
             {{- end }}
-            - --append-dns-names={{ .Values.security.appendDnsNames }}
+            - --append-dns-names={{ .Values.security.enableGenerateWebhookCerts }}
             - --grpc-port=8060
             - --citadel-storage-namespace={{ .Release.Namespace }}
           {{- if .Values.kustomize }}

--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             {{- if .Values.global.sds.enabled }}
             - --sds-enabled=true
             {{- end }}
-            - --append-dns-names=true
+            - --append-dns-names={{ .Values.security.appendDnsNames }}
             - --grpc-port=8060
             - --citadel-storage-namespace={{ .Release.Namespace }}
           {{- if .Values.kustomize }}

--- a/security/citadel/values.yaml
+++ b/security/citadel/values.yaml
@@ -53,3 +53,11 @@ security:
   # “security” and value “S1”.
   podAntiAffinityLabelSelector: []
   podAntiAffinityTermLabelSelector: []
+
+  # This parameter sets the CLI parameter append-dns-names of
+  # Citadel, which:
+  # - If true, Citadel will generate webhook certificates.
+  # - If true, Citadel will not generate webhook certificates.
+  # If there is another component generate webhook certificates,
+  # this parameter should be set as false.
+  appendDnsNames: true

--- a/security/citadel/values.yaml
+++ b/security/citadel/values.yaml
@@ -60,4 +60,4 @@ security:
   # - If true, Citadel will not generate webhook certificates.
   # If there is another component generate webhook certificates,
   # this parameter should be set as false.
-  appendDnsNames: true
+  enableGenerateWebhookCerts: true


### PR DESCRIPTION
Expose the option --append-dns-names, which sets the CLI parameter append-dns-names of Citadel: 
- If true, Citadel will generate webhook certificates.
- If false, Citadel will not generate webhook certificates.
If there is another component generate webhook certificates, this parameter should be set as false.

Design document: https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA

The matching PR on istio/istio: https://github.com/istio/istio/pull/16142

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/8736

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure