### PR TITLE
Add value to include arbitrary spec into prometheus

### DIFF
--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -37,6 +37,9 @@ spec:
   resources:
     requests:
       memory: 400Mi
+{{- if .Values.prometheus.spec }}
+{{ toYaml .Values.prometheus.spec | indent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
With this change we can introduce additional config into the prometheus
operator, to allow configuring things such as persistent storage.