### PR TITLE
Add configurable sidecar injector webhook namespace selector

### DIFF
--- a/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
+++ b/istio-control/istio-autoinject/templates/mutatingwebhook.yaml
@@ -29,7 +29,9 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     namespaceSelector:
-{{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
+{{- if .Values.sidecarInjectorWebhook.namespaceSelector }}
+      {{- toYaml .Values.sidecarInjectorWebhook.namespaceSelector | trim | nindent 6 }}
+{{- else if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:
       - key: name
         operator: NotIn

--- a/istio-control/istio-autoinject/values.yaml
+++ b/istio-control/istio-autoinject/values.yaml
@@ -8,10 +8,26 @@ sidecarInjectorWebhook:
 
   image: sidecar_injector
 
+  # This allows you to set the namespace selector specifically against the WebHook.
+  # This option is supersedes both `injectLabel`, and `enableNamespacesByDefault`.
+  namespaceSelector: {}
+  #  matchExpressions:
+  #    - key: name
+  #      operator: NotIn
+  #      values:
+  #        - default
+  #        - kube-system
+
   # This enables injection of sidecar in all namespaces,
   # with the exception of namespaces with "istio-injection:disabled" annotation
   # Only one environment should have this enabled.
+  # This can only be used when `namespaceSelector` is not set.
   enableNamespacesByDefault: false
+
+  # If set, will use the value as injection label. The value must match the 'release' label of the injector,
+  # except when 1.2 istio-injection label is used, which must be set to "enabled".
+  # This can only be used when `namespaceSelector` is not set.
+  injectLabel: istio-injection
 
   # If true, webhook or istioctl injector will rewrite PodSpec for liveness
   # health check to redirect request to sidecar. This makes liveness check work
@@ -26,9 +42,6 @@ sidecarInjectorWebhook:
   nodeSelector: {}
   tolerations: []
 
-  # If set, will use the value as injection label. The value must match the 'release' label of the injector,
-  # except when 1.2 istio-injection label is used, which must be set to "enabled".
-  injectLabel: istio-injection
 
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are


### PR DESCRIPTION
I submitted a similar change to the older installer at https://github.com/istio/istio/pull/16505 but I'll copy paste the reasoning from that pull request to this one; the implementation is a little bit different over here so I implemented it again a little differently and updated the values file to have some meaningful documentation around how setting this namespaceSelector might affect other configuration options.

> I'm not sure if there's an issue lurking around for something of this nature; but for us we're having some trouble where we essentially want to declare with an annotation on a pod when the sidecar injection is enabled; by default we only have access to that when we label the namespace with istio-injection: enabled. Switching over to the existing variable enableNamespacesByDefault and setting that to true does solve the problem for us but also introduces a new one which is to say inside of kube-system in order for our networking to come up we need to be able to communicate with the istio webhook which obviously can't happen.

> I did consider just directly adding kube-system to the enableNamespacesByDefault configured block and leaving it at that but it seemed like a setting which a user might want more granular control over so I instead set a default value for the namespace selector but made it fully configurable inside of the values file and did not touch the enableNamespacesByDefault in order to not create a breaking change.