### PR TITLE
Add context graph and mesh uid into stackdriver template

### DIFF
--- a/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
@@ -926,6 +926,8 @@ spec:
     destinationWorkloadNamespace: destination.workload.namespace | "Unknown"
     contextProtocol: context.protocol | "Unknown"
     apiProtocol: api.protocol | "Unknown"
+    destinationServiceName: destination.service.name | "Unknown"
+    destinationServiceNamespace: destination.service.namespace | "Unknown"
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule

--- a/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
@@ -110,6 +110,7 @@ spec:
     logInfo:
       server-accesslog-stackdriver.instance.{{ .Release.Namespace }}:
         labelNames:
+        - mesh_uid
         - source_uid
         - source_ip
         - source_app
@@ -148,6 +149,7 @@ spec:
         - referer
       server-tcp-accesslog-stackdriver.instance.{{ .Release.Namespace }}:
         labelNames:
+        - mesh_uid
         - connection_id
         - connection_event
         - source_uid
@@ -259,6 +261,7 @@ spec:
   params:
     value: "1"
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -298,6 +301,7 @@ spec:
   params:
     value: "1"
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -336,6 +340,7 @@ spec:
   params:
     value: request.total_size
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -375,6 +380,7 @@ spec:
   params:
     value: request.total_size
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -413,6 +419,7 @@ spec:
   params:
     value: response.total_size
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -452,6 +459,7 @@ spec:
   params:
     value: response.total_size
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -490,6 +498,7 @@ spec:
   params:
     value: response.duration
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -529,6 +538,7 @@ spec:
   params:
     value: response.duration
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -567,6 +577,7 @@ spec:
   params:
     value: connection.received.bytes | 0
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -602,6 +613,7 @@ spec:
   params:
     value: connection.received.bytes | 0
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -636,6 +648,7 @@ spec:
   params:
     value: connection.sent.bytes | 0
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -671,6 +684,7 @@ spec:
   params:
     value: connection.sent.bytes | 0
     dimensions:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -706,6 +720,7 @@ spec:
     severity: '"Info"'
     timestamp: request.time
     variables:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       source_uid: source.uid | ""
       source_ip: source.ip | ip("0.0.0.0")
       source_app: source.labels["app"] | ""
@@ -765,6 +780,7 @@ spec:
     severity: '"Info"'
     timestamp: context.time | timestamp("2017-01-01T00:00:00Z")
     variables:
+      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
       source_uid: source.uid | ""
       connection_id: connection.id | ""
       connection_event: connection.event | ""
@@ -885,5 +901,45 @@ spec:
   - handler: stackdriver
     instances:
     - stackdriver-span
+{{- end }}
+---
+{{- if .Values.mixer.adapters.stackdriver.contextGraph.enabled }}
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: stackdriver-edge
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-telemetry
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: edge
+  params:
+    timestamp: request.time | context.time | timestamp("2017-01-01T00:00:00Z")
+    sourceUid: source.uid | "Unknown"
+    sourceOwner: source.owner | "Unknown"
+    sourceWorkloadName: source.workload.name | "Unknown"
+    sourceWorkloadNamespace: source.workload.namespace | "Unknown"
+    destinationUid: destination.uid | "Unknown"
+    destinationOwner: destination.owner | "Unknown"
+    destinationWorkloadName: destination.workload.name | "Unknown"
+    destinationWorkloadNamespace: destination.workload.namespace | "Unknown"
+    contextProtocol: context.protocol | "Unknown"
+    apiProtocol: api.protocol | "Unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-edge
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-telemetry
+    release: {{ .Release.Name }}
+spec:
+  match: (context.reporter.kind | "inbound" == "inbound") && (context.protocol | "unknown" != "unknown")
+  actions:
+   - handler: stackdriver
+     instances:
+     - stackdriver-edge
 {{- end }}
 {{- end }}

--- a/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
@@ -261,7 +261,7 @@ spec:
   params:
     value: "1"
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -301,7 +301,7 @@ spec:
   params:
     value: "1"
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -340,7 +340,7 @@ spec:
   params:
     value: request.total_size
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -380,7 +380,7 @@ spec:
   params:
     value: request.total_size
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -419,7 +419,7 @@ spec:
   params:
     value: response.total_size
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -459,7 +459,7 @@ spec:
   params:
     value: response.total_size
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -498,7 +498,7 @@ spec:
   params:
     value: response.duration
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -538,7 +538,7 @@ spec:
   params:
     value: response.duration
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -577,7 +577,7 @@ spec:
   params:
     value: connection.received.bytes | 0
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -613,7 +613,7 @@ spec:
   params:
     value: connection.received.bytes | 0
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -648,7 +648,7 @@ spec:
   params:
     value: connection.sent.bytes | 0
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -684,7 +684,7 @@ spec:
   params:
     value: connection.sent.bytes | 0
     dimensions:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
       destination_port: destination.port | 0
@@ -720,7 +720,7 @@ spec:
     severity: '"Info"'
     timestamp: request.time
     variables:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       source_uid: source.uid | ""
       source_ip: source.ip | ip("0.0.0.0")
       source_app: source.labels["app"] | ""
@@ -780,7 +780,7 @@ spec:
     severity: '"Info"'
     timestamp: context.time | timestamp("2017-01-01T00:00:00Z")
     variables:
-      mesh_uid: '"{{ .Values.mixer.adapters.stackdriver.label.meshUID }}"'
+      mesh_uid: '"{{ .Values.global.meshID }}"'
       source_uid: source.uid | ""
       connection_id: connection.id | ""
       connection_event: connection.event | ""

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -31,6 +31,12 @@ mixer:
         enabled: false
         sampleProbability: 1
 
+      contextGraph:
+        enabled: false
+
+      label:
+        meshUID: ""
+
     # Setting this to false sets the useAdapterCRDs mixer startup argument to false
     useAdapterCRDs: false
 

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -34,9 +34,6 @@ mixer:
       contextGraph:
         enabled: false
 
-      label:
-        meshUID: ""
-
     # Setting this to false sets the useAdapterCRDs mixer startup argument to false
     useAdapterCRDs: false
 


### PR DESCRIPTION
Example command to use the newly added values: `helm template istio-telemetry/mixer-telemetry -x templates/stackdriver.yaml --name istio --namespace istio-system --values global.yaml --set mixer.adapters.stackdriver.enabled=true --set mixer.adapters.stackdriver.contextGraph.enabled=true --set global.meshID=\<mesh_uid\>`

mesh_uid label will just be empty string if not set. cc @elfinhe @djazayeri please take a look, thanks!