### PR TITLE
Add POD_NAMESPACE env variable to mixer containers

### DIFF
--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -111,8 +111,13 @@ spec:
           {{- else }}
           - --trace_zipkin_url=http://zipkin.{{ .Values.global.telemetryNamespace }}:9411/api/v1/spans
           {{- end }}
-        {{- if .Values.mixer.policy.env }}
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        {{- if .Values.mixer.policy.env }}
         {{- range $key, $val := .Values.mixer.policy.env }}
         - name: {{ $key }}
           value: "{{ $val }}"

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -114,8 +114,13 @@ spec:
           {{- else }}
           - --trace_zipkin_url=http://zipkin.{{ .Values.global.telemetryNamespace }}:9411/api/v1/spans
           {{- end }}
-        {{- if .Values.mixer.env }}
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        {{- if .Values.mixer.env }}
         {{- range $key, $val := .Values.mixer.env }}
         - name: {{ $key }}
           value: "{{ $val }}"


### PR DESCRIPTION
Some adapters (e.g. kubernetesenv) might rely on that variable, using
"istio-system" as a fallback value. This is an issue if the control plane
is deployed in another namespace.

Backported from https://github.com/istio/istio/pull/15796