### PR TITLE
Use configNamespace for pilot instead of istioNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,13 +246,13 @@ the default disabled, test it, and move the default from `istio-system` to `isti
 
 ```bash
     # ENABLE_CNI is set to true if istio-cni is installed
-    iop istio-control istio-autoinject $IBASE/istio-control/istio-autoinject --set sidecarInjectorWebhook.enableNamespacesByDefault=true \
+    iop istio-control istio-autoinject $IBASE/istio-control/istio-autoinject --set sidecarInjectorWebhook.enableNamespacesByDefault=true --set global.configNamespace=istio-control \
         --set istio_cni.enabled=${ENABLE_CNI}
 
     # Second auto-inject using master version of istio
     # Notice the different options
     TAG=master-latest-daily HUB=gcr.io/istio-release iop istio-master istio-autoinject-master $IBASE/istio-control/istio-autoinject \
-             --set global.istioNamespace=istio-master
+             --set global.configNamespace=istio-master
 
 ```
 
@@ -275,17 +275,25 @@ Note that running a dedicated Pilot for ingress/gateways is supported and recomm
 but in the case of K8S ingress it is currently required.
 
 ```bash
-    iop istio-ingress istio-ingress $IBASE/gateways/istio-ingress --set global.istioNamespace=istio-master
+    iop istio-ingress istio-ingress $IBASE/gateways/istio-ingress --set global.configNamespace=istio-control
+    TAG=master-latest-daily HUB=gcr.io/istio-release iop istio-ingress-master istio-ingress $IBASE/gateways/istio-ingress \
+            --set global.configNamespace=istio-master\
+
 ```
 
 ## Telemetry
 
 ```bash
-    iop istio-telemetry istio-grafana $IBASE/istio-telemetry/grafana/ --set global.istioNamespace=istio-master
-
-    iop istio-telemetry istio-mixer $IBASE/istio-telemetry/mixer-telemetry/ --set global.istioNamespace=istio-master
-
-    iop istio-telemetry istio-prometheus $IBASE/istio-telemetry/prometheus/ --set global.istioNamespace=istio-master
+    iop istio-telemetry istio-grafana $IBASE/istio-telemetry/grafana/ --set global.configNamespace=istio-control
+    iop istio-telemetry istio-mixer $IBASE/istio-telemetry/mixer-telemetry/ --set global.configNamespace=istio-control
+    iop istio-telemetry istio-prometheus $IBASE/istio-telemetry/prometheus/ --set global.configNamespace=istio-control
+    
+    TAG=master-latest-daily HUB=gcr.io/istio-release iop istio-telemetry-master istio-grafana $IBASE/istio-telemetry/grafana/ \
+            --set global.configNamespace=istio-master
+    TAG=master-latest-daily HUB=gcr.io/istio-release iop istio-telemetry-master istio-mixer $IBASE/istio-telemetry/mixer-telemetry/ \
+            --set global.configNamespace=istio-master
+    TAG=master-latest-daily HUB=gcr.io/istio-release iop istio-telemetry-master istio-prometheus $IBASE/istio-telemetry/prometheus/ \
+            --set global.configNamespace=istio-master
 ```
 
 ## Policy

--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -119,8 +119,8 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          {{- if .Values.global.istioNamespace }}
-          - istio-pilot.{{ .Values.global.istioNamespace }}:15011
+          {{- if .Values.global.configNamespace }}
+          - istio-pilot.{{ .Values.global.configNamespace }}:15011
           {{- else }}
           - istio-pilot:15011
           {{- end }}
@@ -128,8 +128,8 @@ spec:
           - --controlPlaneAuthPolicy
           - NONE
           - --discoveryAddress
-          {{- if .Values.global.istioNamespace }}
-          - istio-pilot.{{ .Values.global.istioNamespace }}:15010
+          {{- if .Values.global.configNamespace }}
+          - istio-pilot.{{ .Values.global.configNamespace }}:15010
           {{- else }}
           - istio-pilot:15010
           {{- end }}

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -160,8 +160,8 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          {{- if .Values.global.istioNamespace }}
-          - istio-pilot.{{ .Values.global.istioNamespace }}:15011
+          {{- if .Values.global.configNamespace }}
+          - istio-pilot.{{ .Values.global.configNamespace }}:15011
           {{- else }}
           - istio-pilot:15011
           {{- end }}
@@ -169,8 +169,8 @@ spec:
           - --controlPlaneAuthPolicy
           - NONE
           - --discoveryAddress
-          {{- if .Values.global.istioNamespace }}
-          - istio-pilot.{{ .Values.global.istioNamespace }}:15010
+          {{- if .Values.global.configNamespace }}
+          - istio-pilot.{{ .Values.global.configNamespace }}:15010
           {{- else }}
           - istio-pilot:15010
           {{- end }}

--- a/istio-control/istio-autoinject/templates/configmap.yaml
+++ b/istio-control/istio-autoinject/templates/configmap.yaml
@@ -71,13 +71,13 @@ data:
       controlPlaneAuthPolicy: MUTUAL_TLS
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot{{ .Values.version }}.{{ .Release.Namespace }}:15011
+      discoveryAddress: istio-pilot{{ .Values.version }}.{{ .Values.global.configNamespace }}:15011
     {{- else }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: NONE
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot{{ .Values.version }}.{{ .Release.Namespace }}:15010
+      discoveryAddress: istio-pilot{{ .Values.version }}.{{ .Values.global.configNamespace }}:15010
     {{- end }}
 ---


### PR DESCRIPTION
pilot is installed in global.configNamespace instead of global.istioNamespace

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>