### PR TITLE
Update CoreDNS version to a more recent one

### DIFF
--- a/istiocoredns/Chart.yaml
+++ b/istiocoredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Istio CoreDNS provides DNS resolution for services in multicluster setups.
 name: istiocoredns
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.1
 tillerVersion: ">=2.7.2"

--- a/istiocoredns/Chart.yaml
+++ b/istiocoredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Istio CoreDNS provides DNS resolution for services in multicluster setups.
 name: istiocoredns
-version: 1.1.1
+version: 1.1.0
 appVersion: 0.1
 tillerVersion: ">=2.7.2"

--- a/istiocoredns/templates/configmap.yaml
+++ b/istiocoredns/templates/configmap.yaml
@@ -11,11 +11,17 @@ data:
     .:53 {
           errors
           health
+          {{ if eq -1 (semver  .Values.coreDNSTag  | (semver "1.4.0").Compare) }}
+          # Removed support for the proxy plugin: https://coredns.io/2019/03/03/coredns-1.4.0-release/
+          grpc . 127.0.0.1:8053
+          forward . /etc/resolv.conf
+          {{ else }}
           proxy global 127.0.0.1:8053 {
             protocol grpc insecure
           }
-          prometheus :9153
           proxy . /etc/resolv.conf
+          {{ end }}
+          prometheus :9153
           cache 30
           reload
         }

--- a/istiocoredns/templates/deployment.yaml
+++ b/istiocoredns/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
 {{- end }}
       containers:
       - name: coredns
-        image: {{ .Values.istiocoredns.coreDNSImage }}
+        image: {{ .Values.istiocoredns.coreDNSImage }}:{{ .Values.istiocoredns.coreDNSTag }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Always" }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:

--- a/istiocoredns/values.yaml
+++ b/istiocoredns/values.yaml
@@ -6,7 +6,8 @@ istiocoredns:
   replicaCount: 1
   rollingMaxSurge: 100%
   rollingMaxUnavailable: 25%
-  coreDNSImage: coredns/coredns:1.1.2
+  coreDNSImage: coredns/coredns
+  coreDNSTag: 1.6.2
   # Source code for the plugin can be found at
   # https://github.com/istio-ecosystem/istio-coredns-plugin
   # The plugin listens for DNS requests from coredns server at 127.0.0.1:8053


### PR DESCRIPTION
This PR updates the CoreDNS version to a more recent one and makes it compatible with CoreDNS versions above 1.3.2 (see: https://github.com/istio/istio/pull/16417). 