### PR TITLE
Typo in istio-cni daemonset template

### DIFF
--- a/istio-cni/templates/daemonset.yaml
+++ b/istio-cni/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         # This container installs the Istio CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .Values.cni.hub }}/{{ .values.cni.image | default "install-cni" }}:{{ .Values.cni.tag }}
+          image: {{ .Values.cni.hub }}/{{ .Values.cni.image | default "install-cni" }}:{{ .Values.cni.tag }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
           command: ["/install-cni.sh"]
           env:


### PR DESCRIPTION
Fixing a small typo in the istio-cni Helm template.