### PR TITLE
allow long protocol detection timeout for test

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -120,7 +120,7 @@ global:
     # the specified period, defaulting to non mTLS plain TCP
     # traffic. Set this field to tweak the period that Envoy will wait
     # for the client to send the first bits of data. (MUST BE >=1ms)
-    protocolDetectionTimeout: 10ms
+    protocolDetectionTimeout: 150ms
 
     #If set to true, istio-proxy container will have privileged securityContext
     privileged: false


### PR DESCRIPTION
```    
    # Automatic protocol detection uses a set of heuristics to
    # determine whether the connection is using TLS or not (on the
    # server side), as well as the application protocol being used
    # (e.g., http vs tcp). These heuristics rely on the client sending
    # the first bits of data. For server first protocols like MySQL,
    # MongoDB, etc., Envoy will timeout on the protocol detection after
    # the specified period, defaulting to non mTLS plain TCP
    # traffic. Set this field to tweak the period that Envoy will wait
    # for the client to send the first bits of data. (MUST BE >=1ms)