### PR TITLE
Grant Citadel namespace read permission to triage failing TestNamespaceTargeting test

### DIFF
--- a/kustomize/citadel/citadel.yaml
+++ b/kustomize/citadel/citadel.yaml
@@ -47,7 +47,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
+  resources: ["serviceaccounts", "services", "namespaces"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]

--- a/kustomize/cluster/clusterrole-12.yaml
+++ b/kustomize/cluster/clusterrole-12.yaml
@@ -158,7 +158,7 @@ rules:
     resources: ["secrets"]
     verbs: ["create", "get", "watch", "list", "update", "delete"]
   - apiGroups: [""]
-    resources: ["serviceaccounts", "services"]
+    resources: ["serviceaccounts", "services", "namespaces"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]

--- a/kustomize/default/gen-istio-citadel.yaml
+++ b/kustomize/default/gen-istio-citadel.yaml
@@ -47,7 +47,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
+  resources: ["serviceaccounts", "services", "namespaces"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]

--- a/kustomize/istio-1.2/default/istio.yaml
+++ b/kustomize/istio-1.2/default/istio.yaml
@@ -1655,7 +1655,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
+  resources: ["serviceaccounts", "services", "namespaces"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]

--- a/security/citadel/templates/clusterrole.yaml
+++ b/security/citadel/templates/clusterrole.yaml
@@ -14,7 +14,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
+  resources: ["serviceaccounts", "services", "namespaces"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]

--- a/test/demo/gen-istio.yaml
+++ b/test/demo/gen-istio.yaml
@@ -28,7 +28,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "services"]
+  resources: ["serviceaccounts", "services", "namespaces"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]


### PR DESCRIPTION
The `TestNamespaceTargeting` has been [blocking](https://github.com/istio/istio/issues/16684) installer `release-1.3` CI. #335 was submitted to fix RBAC two weeks ago, but the fix doesn't seem to be in the release, and [cherry-picking](https://github.com/istio/installer/pull/335#issuecomment-526453398) onto `release-1.3` fails due to relocated perm files. This change manually fixes the permissions.

@rlenglet @howardjohn for more context on the installer.