### PR TITLE
Make envoy configMap optional

### DIFF
--- a/istio-control/istio-config/templates/configmap-envoy.yaml
+++ b/istio-control/istio-config/templates/configmap-envoy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.controlPlaneSecurityEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -86,5 +87,5 @@ data:
                 trusted_ca:
                   filename: /etc/certs/root-cert.pem
             require_client_certificate: true
+{{- end }}
 ---
-

--- a/istio-control/istio-config/templates/configmap-mesh.yaml
+++ b/istio-control/istio-config/templates/configmap-mesh.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 data:
-
-
   mesh: |-
 {{ toYaml .Values.galley.mesh | indent 4 }}
 ---

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -152,14 +152,12 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
-
           volumeMounts:
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
           - name: envoy-config
             mountPath: /var/lib/istio/galley/envoy
-
 {{- end }}
 
       volumes:
@@ -167,11 +165,11 @@ spec:
       - name: istio-certs
         secret:
           secretName: istio.istio-galley-service-account
-{{- if .Values.global.controlPlaneSecurityEnabled }}
+  {{- end }}
+  {{- if .Values.global.controlPlaneSecurityEnabled }}
       - name: envoy-config
         configMap:
           name: galley-envoy-config
-{{- end }}
   {{- end }}
       - name: config
         configMap:

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -167,9 +167,11 @@ spec:
       - name: istio-certs
         secret:
           secretName: istio.istio-galley-service-account
+{{- if .Values.global.controlPlaneSecurityEnabled }}
       - name: envoy-config
         configMap:
           name: galley-envoy-config
+{{- end }}
   {{- end }}
       - name: config
         configMap:


### PR DESCRIPTION
This PR makes the creation of the `envy-configmap` used by galley optional. Only if `controlPlaneSecurityEnabled: true` is set the ConfigMap and the Sidecar will be deployed. Before ConfigMap was always deployed (even if it wasn't used).