### PR TITLE
Remove unnecessary defaults

### DIFF
--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -12,8 +12,6 @@ spec:
 {{- if not $gateway.autoscaleEnabled }}
 {{- if $gateway.replicaCount }}
   replicas: {{ $gateway.replicaCount }}
-{{- else }}
-  replicas: 1
 {{- end }}
 {{- end }}
   selector:

--- a/gateways/istio-egress/templates/poddisruptionbudget.yaml
+++ b/gateways/istio-egress/templates/poddisruptionbudget.yaml
@@ -1,4 +1,3 @@
-{{ $gateway := index .Values "gateways" "istio-egressgateway" }}
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -12,8 +12,6 @@ spec:
 {{- if not $gateway.autoscaleEnabled }}
 {{- if $gateway.replicaCount }}
   replicas: {{ $gateway.replicaCount }}
-{{- else }}
-  replicas: 1
 {{- end }}
 {{- end }}
   selector:

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     istio: sidecar-injector
 spec:
+{{- if .Values.sidecarInjectorWebhook.replicaCount }}
   replicas: {{ .Values.sidecarInjectorWebhook.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       istio: sidecar-injector

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -18,8 +18,6 @@ spec:
 {{- if not .Values.pilot.autoscaleEnabled }}
 {{- if .Values.pilot.replicaCount }}
   replicas: {{ .Values.pilot.replicaCount }}
-{{- else }}
-  replicas: 1
 {{- end }}
 {{- end }}
   strategy:

--- a/istio-policy/templates/autoscale.yaml
+++ b/istio-policy/templates/autoscale.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mixer.policy.autoscaleMin }}
+{{- if and .Values.mixer.policy.autoscaleEnabled .Values.mixer.policy.autoscaleMin .Values.mixer.policy.autoscaleMax }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -8,7 +8,11 @@ metadata:
     istio: mixer
     release: {{ .Release.Name }}
 spec:
+{{- if not .Values.mixer.policy.autoscaleEnabled }}
+{{- if .Values.mixer.policy.replicaCount }}
   replicas: {{ .Values.mixer.policy.replicaCount }}
+{{- end }}
+{{- end }}
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.mixer.policy.rollingMaxSurge }}
@@ -217,4 +221,3 @@ spec:
           mountPath: /sock
 {{- end }}
 ---
-


### PR DESCRIPTION
This PR removes the need for the if/else branch on `replicaCount ` since Kubernetes will set the default of 1 replica anyway.