### PR TITLE
Add label name to namespaces

### DIFF
--- a/bin/iop
+++ b/bin/iop
@@ -55,6 +55,8 @@ function iop() {
         # Apply will make sure that any old config with the same tag that is no longer present will
         # be removed. The release MUST be unique across cluster.
         kubectl create  ns $ns > /dev/null  2>&1
+        #set label 'name' to namespace which is required if enableNamespacesByDefault is true. 
+        kubectl label namespace $ns name=$ns --overwrite
 
         if [ "$ISTIO_ENV" != "" ]; then
             kubectl label namespace $ns istio-env=$ISTIO_ENV --overwrite


### PR DESCRIPTION
Cannot have sidecar pod running successfully if run this command which is mentioned in https://github.com/istio/installer readme. 
```
    iop istio-control istio-autoinject $IBASE/istio-control/istio-autoinject --set sidecarInjectorWebhook.enableNamespacesByDefault=true --set global.configNamespace=istio-control 
```
That is because the `mutatingwebhookconfiguration` is applied to `istio-sidecar-injector` as well. `  Warning  FailedCreate  0s (x12 over 27s)  replicaset-controller  Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": Post https://istio-sidecar-injector.istio-control.svc:443/inject?timeout=30s: dial tcp 10.102.56.213:443: connect: connection refused`

the fix is to add label `name` during creating namespace
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>