### PR TITLE
set protocol detection timeout for outbound listener

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -120,7 +120,7 @@ global:
     # the specified period, defaulting to non mTLS plain TCP
     # traffic. Set this field to tweak the period that Envoy will wait
     # for the client to send the first bits of data. (MUST BE >=1ms)
-    protocolDetectionTimeout: 1s
+    protocolDetectionTimeout: 100ms
 
     #If set to true, istio-proxy container will have privileged securityContext
     privileged: false


### PR DESCRIPTION
Protocol detection timeout for inbound listener is set by Pilot env variable. Default 1s