### PR TITLE
Add back NodePort 31380 31390

### DIFF
--- a/gateways/istio-ingress/values.yaml
+++ b/gateways/istio-ingress/values.yaml
@@ -30,8 +30,10 @@ gateways:
     - port: 80
       targetPort: 80
       name: http2
+      nodePort: 31380
     - port: 443
       name: https
+      nodePort: 31390
     - port: 15029
       targetPort: 15029
       name: kiali


### PR DESCRIPTION
To keep consistence with istio/istio. I should be able to access the bookinfo example by using 31380 port.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>