### PR TITLE
Add the possibility to create RoleBinding for PSP

### DIFF
--- a/istio-cni/templates/clusterrolebinding.yaml
+++ b/istio-cni/templates/clusterrolebinding.yaml
@@ -13,3 +13,19 @@ subjects:
 - kind: ServiceAccount
   name: istio-cni
   namespace: {{ .Release.Namespace }}
+---
+{{- if .Values.psp_cluster_role }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istio-cni-psp
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.psp_cluster_role }}
+subjects:
+  kind: ServiceAccount
+  name: istio-cni
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/istio-cni/templates/clusterrolebinding.yaml
+++ b/istio-cni/templates/clusterrolebinding.yaml
@@ -14,7 +14,7 @@ subjects:
   name: istio-cni
   namespace: {{ .Release.Namespace }}
 ---
-{{- if .Values.psp_cluster_role }}
+{{- if hasKey .Values "psp_cluster_role" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/istio-cni/templates/clusterrolebinding.yaml
+++ b/istio-cni/templates/clusterrolebinding.yaml
@@ -14,7 +14,7 @@ subjects:
   name: istio-cni
   namespace: {{ .Release.Namespace }}
 ---
-{{- if hasKey .Values.cni "psp_cluster_role" }}
+{{- if ne .Values.cni.psp_cluster_role "" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/istio-cni/templates/clusterrolebinding.yaml
+++ b/istio-cni/templates/clusterrolebinding.yaml
@@ -14,7 +14,7 @@ subjects:
   name: istio-cni
   namespace: {{ .Release.Namespace }}
 ---
-{{- if hasKey .Values "psp_cluster_role" }}
+{{- if hasKey .Values.cni "psp_cluster_role" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -23,7 +23,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.psp_cluster_role }}
+  name: {{ .Values.cni.psp_cluster_role }}
 subjects:
 - kind: ServiceAccount
   name: istio-cni

--- a/istio-cni/templates/clusterrolebinding.yaml
+++ b/istio-cni/templates/clusterrolebinding.yaml
@@ -25,7 +25,7 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.psp_cluster_role }}
 subjects:
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: istio-cni
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/istio-cni/values.yaml
+++ b/istio-cni/values.yaml
@@ -19,3 +19,9 @@ cni:
     - istio-system
 
   podAnnotations: {}
+
+  # If this value is set a RoleBinding will be created
+  # in the same namespace as the istio-cni DaemonSet is created.
+  # This can be used to bind a preexisting ClusterRole to the istio/cni ServiceAccount
+  # e.g. if you use PodSecurityPolicies
+  psp_cluster_role: ""


### PR DESCRIPTION
This allows a user to specify a `psp_cluster_role` which points to a `ClusterRole` that sets the according `PodSecurityPolicy`. With this PR you don't need additional scripts/templates to create the `RoleBinding`.

For the other components some PR's will follow (and docs).