### PR TITLE
Add service.type and service.loadBalancerIP for kiali service

### DIFF
--- a/istio-telemetry/kiali/templates/service.yaml
+++ b/istio-telemetry/kiali/templates/service.yaml
@@ -3,13 +3,29 @@ kind: Service
 metadata:
   name: kiali
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $val := .Values.kiali.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.kiali.service.type }}
   ports:
-    - name: http-kiali
+    - name: {{ .Values.kiali.service.name }}
       protocol: TCP
-      port: 20001
+      targetPort: 20001
+      port: {{ .Values.kiali.service.externalPort }}
   selector:
     app: kiali
+{{- if .Values.kiali.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.grafana.service.loadBalancerIP }}"
+{{- end }}
+  {{if .Values.kiali.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{range $rangeList := .Values.kiali.service.loadBalancerSourceRanges}}
+    - {{ $rangeList }}
+    {{end}}
+  {{end}}
+

--- a/istio-telemetry/kiali/values.yaml
+++ b/istio-telemetry/kiali/values.yaml
@@ -9,6 +9,13 @@ kiali:
   image: kiali
   contextPath: /kiali # The root context path to access the Kiali UI.
   nodeSelector: {}
+  service:
+    annotations: {}
+    name: http-kiali
+    type: ClusterIP
+    externalPort: 20001
+    loadBalancerIP:
+    loadBalancerSourceRanges:
 
   # Specify the pod anti-affinity that allows you to constrain which nodes
   # your pod is eligible to be scheduled based on labels on pods that are


### PR DESCRIPTION
Current users login kiali dashboard by ingress.
After adding this pr, we can login it by NodePort service or
loadBalancerIP.

[x] Installation
