### PR TITLE
WIP: feature request: Add a helm values flag for deploying ingressgateway as DaemonSet

### DIFF
--- a/gateways/istio-ingress/templates/autoscale.yaml
+++ b/gateways/istio-ingress/templates/autoscale.yaml
@@ -1,5 +1,6 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
 {{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
+{{- if not $gateway.daemonsetEnabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -21,4 +22,5 @@ spec:
         name: cpu
         targetAverageUtilization: {{ $gateway.cpu.targetAverageUtilization }}
 ---
+{{- end }}
 {{- end }}

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -1,6 +1,10 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
 apiVersion: apps/v1
+{{- if not $gateway.daemonsetEnabled }}
 kind: Deployment
+{{- else }}
+kind: DaemonSet
+{{- end }}
 metadata:
   name: istio-ingressgateway
   namespace: {{ .Release.Namespace }}
@@ -9,7 +13,7 @@ metadata:
     istio: ingressgateway
     release: {{ .Release.Name }}
 spec:
-{{- if not $gateway.autoscaleEnabled }}
+{{- if and (not $gateway.autoscaleEnabled) (not $gateway.daemonsetEnabled) }}
 {{- if $gateway.replicaCount }}
   replicas: {{ $gateway.replicaCount }}
 {{- else }}
@@ -20,10 +24,17 @@ spec:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
+  {{- if not $gateway.daemonsetEnabled }}
   strategy:
     rollingUpdate:
       maxSurge: {{ $gateway.rollingMaxSurge }}
       maxUnavailable: {{ $gateway.rollingMaxUnavailable }}
+  {{- else }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ $gateway.rollingMaxUnavailable }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/gateways/istio-ingress/values.yaml
+++ b/gateways/istio-ingress/values.yaml
@@ -56,6 +56,7 @@ gateways:
     autoscaleEnabled: true
     autoscaleMin: 1
     autoscaleMax: 5
+    # daemonsetEnabled: false #change to true to deploy as "kind: DaemonSet" otherwise "kind: Deployment"
 
     cpu:
       targetAverageUtilization: 80


### PR DESCRIPTION
Makes `kind` of istio-ingressgateway pod template configurable for deploying as `DaemonSet` via Helm values. 

* if `gateways.istio-ingressgateway.daemonsetEnabled` is `false` or `nil`, istio-ingressgateway is deployed as `Deployment` as usual
  * and its `HorizontalPodAutoscaler` is also deployed
* if `gateways.istio-ingressgateway.daemonsetEnabled` is `true`, istio-ingressgateway is deployed as `DaemonSet` with `updateStrategy` field
  * and its `HorizontalPodAutoscaler` is NOT deployed

I think this flag is useful when "externalTrafficPolicy" is set to "Local".
How is it ?