### PR TITLE
Run in minikube instead of kind

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,14 +196,10 @@ jobs:
       - checkout
       - run: bin/testEnvRootMinikube.sh start
       - run: bin/testEnvRootMinikube.sh wait
-      - run: make gitdep
       - run:
-          # Create KIND cluster (separate so we get time info)
-          command: make info dep prepare
+          command: make info dep
       - run:
-          command: make sync
-      - run:
-          command: make docker-run-test TEST_TARGET="run-test-demo"
+          command: make git.dep run-test-demo
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:

--- a/bin/testEnvRootMinikube.sh
+++ b/bin/testEnvRootMinikube.sh
@@ -17,6 +17,7 @@
 export K8S_VER=${K8S_VER:-v1.14.0}
 export MINIKUBE_VER=${MINIKUBE_VER:-v1.0.0}
 export HELM_VER=${HELM_VER:-v2.13.1}
+export ISTIO_VER=${ISTIO_VER:-1.3.0}
 set -x
 
 if [ ! -f /usr/local/bin/minikube ]; then
@@ -27,6 +28,9 @@ if [ ! -f /usr/local/bin/kubectl ]; then
 fi
 if [ ! -f /usr/local/bin/helm ]; then
    curl -Lo helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VER}-linux-amd64.tar.gz && tar -zxvf helm.tgz && chmod +x linux-amd64/helm && sudo mv linux-amd64/helm /usr/local/bin/
+fi
+if [ ! -f /usr/local/bin/istioctl ]; then
+   curl -Lo istio.tgz https://github.com/istio/istio/releases/download/${ISTIO_VER}/istio-${ISTIO_VER}-linux.tar.gz && tar -zxvf istio.tgz && chmod +x istio-${ISTIO_VER}/bin/istioctl && sudo mv istio-${ISTIO_VER}/bin/istioctl /usr/local/bin/
 fi
 
 


### PR DESCRIPTION
we have target `install-minikube`, but the `run-test-demo` does not run in minikube cluster. it is running in `kind` cluster. due to resource limit `2 cpu and 2 GB memory`, it leads to cannot connect to `etcdserver` or `timeout` sometimes.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>