### PR TITLE
Configure webhooks of Galley and Sidecar Injector based on DNS certificate provisioning

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -479,11 +479,17 @@ global:
   # Configures DNS certificates provisioned through Chiron linked into Pilot.
   # The DNS names in this file are all hard-coded; please ensure the namespaces
   # in dnsNames are consistent with those of your services.
-  certificates:
-    - secretName: dns.istio-galley-service-account
-      dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
-    - secretName: dns.istio-sidecar-injector-service-account
-      dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
+  # Example:
+  # certificates:
+  #   - secretName: dns.istio-galley-service-account
+  #     dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
+  #   - secretName: dns.istio-sidecar-injector-service-account
+  #     dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
+  #
+  # When certificates are non-empty, Galley and Sidecar Injector will not manage their
+  # own webhook configurations. The current behavior of Galley and Sidecar Injector
+  # is that they manage their own webhook configurations.
+  certificates: []
 
 # Internal setting - used when generating helm templates for kustomize.
 # clusterResources controls the inclusion of cluster-wide resources when generating the charts/installing.

--- a/global.yaml
+++ b/global.yaml
@@ -485,11 +485,15 @@ global:
   #     dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
   #   - secretName: dns.istio-sidecar-injector-service-account
   #     dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
-  #
-  # When certificates are non-empty, Galley and Sidecar Injector will not manage their
-  # own webhook configurations. The current behavior of Galley and Sidecar Injector
-  # is that they manage their own webhook configurations.
-  certificates: []
+  certificates:
+    - secretName: dns.istio-galley-service-account
+      dnsNames: [istio-galley.istio-system.svc, istio-galley.istio-system]
+    - secretName: dns.istio-sidecar-injector-service-account
+      dnsNames: [istio-sidecar-injector.istio-system.svc, istio-sidecar-injector.istio-system]
+
+  # Configures whether Operator manages webhook configurations. The current behavior
+  # of Galley and Sidecar Injector is that they manage their own webhook configurations.
+  operator: false
 
 # Internal setting - used when generating helm templates for kustomize.
 # clusterResources controls the inclusion of cluster-wide resources when generating the charts/installing.

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
             - --port=9443
             - --healthCheckInterval=2s
             - --healthCheckFile=/tmp/health
+{{- if .Values.global.certificates }}
+            - --reconcileWebhookConfig=false
+{{- else }}
+            - --reconcileWebhookConfig=true
+{{- end }}
                   {{- if eq .Release.Namespace "istio-system"}}
             - --webhookConfigName=istio-sidecar-injector
                   {{ else }}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - --port=9443
             - --healthCheckInterval=2s
             - --healthCheckFile=/tmp/health
-{{- if .Values.global.certificates }}
+{{- if .Values.global.operator }}
             - --reconcileWebhookConfig=false
 {{- else }}
             - --reconcileWebhookConfig=true

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
   {{- else }}
           - --enable-validation=false
   {{- end }}
-  {{- if .Values.global.certificates }}
+  {{- if .Values.global.operator }}
           - --enable-reconcileWebhookConfiguration=false
   {{- else }}
           - --enable-reconcileWebhookConfiguration=true

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
   {{- else }}
           - --enable-validation=false
   {{- end }}
+  {{- if .Values.global.certificates }}
+          - --enable-reconcileWebhookConfiguration=false
+  {{- else }}
+          - --enable-reconcileWebhookConfiguration=true
+  {{- end }}
           - --enable-server=true
   {{- if .Values.galley.enableAnalysis }}
           - --enableAnalysis=true


### PR DESCRIPTION
Configure the webhook configurations of Galley and Sidecar Injector based on DNS certificate provisioning: (the approach is this PR is same as that of https://github.com/istio/istio/pull/16118 and https://github.com/istio/istio/pull/16121).
- If DNS certificates are provisioned, Galley and Sidecar Injector will not configure their own webhook configurations.
- Otherwise, Galley and Sidecar Injector configure their own webhook configurations (their current behavior).

This PR depends on: https://github.com/istio/istio/pull/16121

Please provide a description for what this PR is for: https://github.com/istio/istio/issues/17061

Design documents:
[1]https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA/edit#heading=h.qex63c29z2to
[2] https://docs.google.com/document/d/1v8BxI07u-mby5f5rCruwF7odSXgb9G8-C9W5hQtSIAg/edit#heading=h.xw1gqgyqs5b