### PR TITLE
Add LDAP support to Kiali

### DIFF
--- a/istio-telemetry/kiali/Chart.yaml
+++ b/istio-telemetry/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
 name: kiali
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.4.0
+appVersion: 1.4.0
 tillerVersion: ">=2.7.2"

--- a/istio-telemetry/kiali/templates/configmap.yaml
+++ b/istio-telemetry/kiali/templates/configmap.yaml
@@ -15,10 +15,10 @@ data:
       prometheus: {{ .Values.global.prometheusNamespace }}
     istio_namespace: {{ .Values.global.istioNamespace }}
     auth:
-      strategy: {{ .Values.dashboard.auth.strategy }}
-{{- if eq .Values.dashboard.auth.strategy "ldap" }}
+      strategy: {{ .Values.kiali.dashboard.auth.strategy }}
+{{- if eq .Values.kiali.dashboard.auth.strategy "ldap" }}
       ldap:
-{{- with .Values.dashboard.auth.strategy.ldap }}
+{{- with .Values.kiali.dashboard.auth.strategy.ldap }}
 {{ toYaml . | indent 8 }}
 {{- end }}
 {{- end }}

--- a/istio-telemetry/kiali/templates/configmap.yaml
+++ b/istio-telemetry/kiali/templates/configmap.yaml
@@ -14,6 +14,14 @@ data:
       pilot: {{ .Values.global.configNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
     istio_namespace: {{ .Values.global.istioNamespace }}
+    auth:
+      strategy: {{ .Values.dashboard.auth.strategy }}
+{{- if eq .Values.dashboard.auth.strategy "ldap" }}
+      ldap:
+{{- with .Values.dashboard.auth.strategy.ldap }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end }}
     server:
       port: 20001
 {{- if .Values.kiali.contextPath }}

--- a/istio-telemetry/kiali/templates/demosecret.yaml
+++ b/istio-telemetry/kiali/templates/demosecret.yaml
@@ -11,4 +11,4 @@ type: Opaque
 data:
   username: YWRtaW4=   # admin
   passphrase: YWRtaW4= # admin
-  {{- end }}
+{{- end }}

--- a/istio-telemetry/kiali/values.yaml
+++ b/istio-telemetry/kiali/values.yaml
@@ -64,7 +64,6 @@ kiali:
       #   ldap_user_filter: "(cn=%s)"
       #   ldap_user_id_key: "cn"
 
-    createDemoSecret: true # When true, a secret will be created with a default username and password. Useful for demos.
     secretName: kiali # You must create a secret with this name - one is not provided out-of-box unless you've chose to create a demo secret.
     usernameKey: username # This is the key name within the secret whose value is the actual username.
     passphraseKey: passphrase # This is the key name within the secret whose value is the actual passphrase.
@@ -74,7 +73,7 @@ kiali:
     grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.
     jaegerURL:  # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
 
-
+  createDemoSecret: true # When true, a secret will be created with a default username and password. Useful for demos.
 
   resources: {}
   security:

--- a/istio-telemetry/kiali/values.yaml
+++ b/istio-telemetry/kiali/values.yaml
@@ -47,15 +47,35 @@ kiali:
     #     - kiali.local
 
   dashboard:
-    secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
+    auth:
+      strategy: login # Can be anonymous, login, or openshift
+      # ldap: # This is required to use the ldap strategy
+      #   ldap_base: "DC=example,DC=com"
+      #   ldap_bind_dn: "CN={USERID},OU=xyz,OU=Users,OU=Accounts,DC=example,DC=com"
+      #   ldap_group_filter: "(cn=%s)"
+      #   ldap_host: "ldap-service.ldap-namespace"
+      #   ldap_insecure_skip_verify: true
+      #   ldap_mail_id_key: "mail"
+      #   ldap_member_of_key: "memberOf"
+      #   ldap_port: 123
+      #   ldap_role_filter: ".*xyz.*"
+      #   ldap_search_filter: "(&(name={USERID}))"
+      #   ldap_use_ssl: false
+      #   ldap_user_filter: "(cn=%s)"
+      #   ldap_user_id_key: "cn"
+
+    createDemoSecret: true # When true, a secret will be created with a default username and password. Useful for demos.
+    secretName: kiali # You must create a secret with this name - one is not provided out-of-box unless you've chose to create a demo secret.
     usernameKey: username # This is the key name within the secret whose value is the actual username.
     passphraseKey: passphrase # This is the key name within the secret whose value is the actual passphrase.
+
     viewOnlyMode: false # Bind the service account to a role with only read access
+
     grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.
     jaegerURL:  # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
 
-  # When true, a secret will be created with a default username and password. Useful for demos.
-  createDemoSecret: true
+
+
   resources: {}
   security:
     enabled: true

--- a/istio-telemetry/kiali/values.yaml
+++ b/istio-telemetry/kiali/values.yaml
@@ -48,7 +48,7 @@ kiali:
 
   dashboard:
     auth:
-      strategy: login # Can be anonymous, login, or openshift
+      strategy: login # Can be anonymous, login, openshift, or ldap
       # ldap: # This is required to use the ldap strategy
       #   ldap_base: "DC=example,DC=com"
       #   ldap_bind_dn: "CN={USERID},OU=xyz,OU=Users,OU=Accounts,DC=example,DC=com"


### PR DESCRIPTION
Kiali supports using LDAP for authentication but the current Helm chart didn't enable the LDAP settings to be added to the config map if the auth strategy was set to ldap. This pull request enbles the setting of the LDAP values.

Fixes: https://github.com/istio/istio/issues/17077
Related to: https://github.com/istio/istio/pull/17526