### PR TITLE
Add trust domain and trust domain aliases to Pilot configmap

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -369,6 +369,14 @@ global:
   #   else:  default dns domain
   trustDomain: ""
 
+  #  The trust domain aliases represent the aliases of trust_domain.
+  #  For example, if we have
+  #  trustDomain: td1
+  #  trustDomainAliases: [“td2”, "td3"]
+  #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
+  #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+  trustDomainAliases: []
+
   # Mesh ID means Mesh Identifier. It should be unique within the scope where
   # meshes will interact with each other, but it is not required to be
   # globally/universally unique. For example, if any of the following are true,

--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -81,6 +81,21 @@ data:
     {{- end }}
     {{- end }}
 
+    # The trust domain corresponds to the trust root of a system.
+    # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
+    trustDomain: {{ .Values.global.trustDomain | quote }}
+
+    #  The trust domain aliases represent the aliases of trust_domain.
+    #  For example, if we have
+    #  trustDomain: td1
+    #  trustDomainAliases: [“td2”, "td3"]
+    #  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",
+    #  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+    trustDomainAliases:
+      {{- range .Values.global.trustDomainAliases }}
+      - {{ . | quote }}
+      {{- end }}
+
     {{- if .Values.global.sds.enabled }}
     # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get
     # key/cert for mTLS. Use secret-mount files instead of SDS if set to empty.


### PR DESCRIPTION
Change for the new installer for Pilot to generate RBAC config based on trust domain and trust domain aliases. 

From https://github.com/istio/istio/pull/17594