### PR TITLE
When Operator manages webhooks, Galley and Sidecar Injector are deprivileged

### DIFF
--- a/istio-control/istio-autoinject/templates/clusterrole.yaml
+++ b/istio-control/istio-autoinject/templates/clusterrole.yaml
@@ -11,7 +11,9 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["istio-sidecar-injector"]
   verbs: ["get", "list", "watch"]
+{{- if not .Values.global.operatorManageWebhooks }}
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
   resourceNames: ["istio-sidecar-injector", "istio-sidecar-injector-{{.Release.Namespace}}"]
   verbs: ["get", "list", "watch", "patch"]
+{{- end }}

--- a/istio-control/istio-config/templates/clusterrole.yaml
+++ b/istio-control/istio-config/templates/clusterrole.yaml
@@ -23,9 +23,11 @@ rules:
     "security.istio.io"]
     resources: ["*/status"]
     verbs: ["update"]
+{{- if not .Values.global.operatorManageWebhooks }}
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["*"]
+{{- end }}
   - apiGroups: ["extensions","apps"]
     resources: ["deployments"]
     resourceNames: ["istio-galley"]


### PR DESCRIPTION
Please provide a description for what this PR is for: https://github.com/istio/istio/issues/17061

Design documents:
[1]https://docs.google.com/document/d/1VHyBre8943USOx_YEVtA18KfEoGTmLT1iBHESO5bzcA/edit#heading=h.qex63c29z2to
[2] https://docs.google.com/document/d/1v8BxI07u-mby5f5rCruwF7odSXgb9G8-C9W5hQtSIAg/edit#heading=h.xw1gqgyqs5b

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
