### PR TITLE
change egress hpa name to consume operator requirement (#444)

### DIFF
--- a/gateways/istio-egress/templates/autoscale.yaml
+++ b/gateways/istio-egress/templates/autoscale.yaml
@@ -3,7 +3,7 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: egressgateway
+  name: istio-egressgateway
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-egressgateway


### PR DESCRIPTION
(cherry picked from commit 389e25a7633c302d2452b071bcebcdd844ec6266)