### PR TITLE
Update auto mTLS the one we used for istio/istio test

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -260,6 +260,7 @@ global:
       address: "$(HOST_IP):8126"
 
   # Default mtls policy. If true, mtls between services will be enabled by default.
+  # Any of fields in this section requires security component to be enabled.
   mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.
@@ -268,7 +269,7 @@ global:
     # or its DestinationRule does not have TLSSettings specified, Istio configures client side
     # TLS configuration automatically, based on the server side mTLS authentication policy and the
     # availibity of sidecars.
-    auto: false
+    auto: true
 
   # ImagePullSecrets for all ServiceAccount, list of secrets in the same namespace
   # to use for pulling any images in pods that reference this ServiceAccount.

--- a/test/demo/values.yaml
+++ b/test/demo/values.yaml
@@ -17,6 +17,9 @@ global:
   # Reflects in pilot config - should move to proper API and istio-config
   disablePolicyChecks: false
 
+  mtls:
+    auto: true
+
   sidecarInjectorWebhook:
     enabled: true
     # If true, webhook or istioctl injector will rewrite PodSpec for liveness


### PR DESCRIPTION
Apparently this demo folder is actually being used, not the globa.yaml

https://github.com/istio/istio/issues/14524

https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/18030/integ-new-install-k8s-tests_istio/2134/build-log.txt
search for "/demo"

