### PR TITLE
auto mtls on by default in demo, used in istio/istio test

### DIFF
--- a/test/demo/values.yaml
+++ b/test/demo/values.yaml
@@ -6,6 +6,9 @@ global:
   defaultPodDisruptionBudget:
     enabled:
       false
+  
+  mtls:
+    auto: true
 
   proxy:
     accessLogFile: "/dev/stdout"


### PR DESCRIPTION
Apparently this demo folder is actually being used, not the global.yaml

istio/istio#14524

https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/18030/integ-new-install-k8s-tests_istio/2134/build-log.txt
search for "/demo"