### PR TITLE
create MeshPolicy using global.mtls.enabled 

### DIFF
--- a/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -1,3 +1,9 @@
+{{- /*
+
+TODO(https://github.com/istio/istio/issues/18199) remove this configuration from charts once the operator starts managing it
+
+*/ -}}
+
 {{ if .Values.clusterResources }}
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
 # Customer should add similar destination rules for other services that dont' have sidecar.
@@ -18,6 +24,18 @@ spec:
 
 {{- if .Values.global.mtls.enabled }}
 
+# Authentication policy to enable mutual TLS for all services (that have sidecar) in the mesh.
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  peers:
+  - mtls: {}
+---
 # Corresponding destination rule to configure client side to use mutual TLS when talking to
 # any service (host) in the mesh.
 apiVersion: networking.istio.io/v1alpha3
@@ -34,7 +52,19 @@ spec:
       mode: ISTIO_MUTUAL
 ---
 {{- else }}
-
+# Authentication policy to enable permissive mode for all services (that have sidecar) in the mesh.
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  peers:
+  - mtls:
+      mode: PERMISSIVE
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:


### PR DESCRIPTION
The helm charts from istio/istio create MeshPolicy when
global.mtls.enabled=true. The new istio/installer charts and operator
do not despite the API defining a global.mtls.enabled option. Long
term the operator should update MeshPolicy based on the MeshConfig. In
the short term (~1.4) the istio/installer and operator will be updated
to match the existing behavior to not surprise user

ref: https://github.com/istio/istio/issues/18199

manual cherry-pick of (#450)
