### PR TITLE
remove namespace for meshpolicy resource.

### DIFF
--- a/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -29,7 +29,6 @@ apiVersion: "authentication.istio.io/v1alpha1"
 kind: "MeshPolicy"
 metadata:
   name: "default"
-  namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
 spec:
@@ -57,7 +56,6 @@ apiVersion: "authentication.istio.io/v1alpha1"
 kind: "MeshPolicy"
 metadata:
   name: "default"
-  namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
resolve: https://github.com/istio/istio/issues/18318
`meshpolicy` is cluster scoped resource, add namespace will generate invalid status for operator controller.
