### PR TITLE
remove the usage of applicationPorts

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -249,7 +249,6 @@ function localSidecar() {
         --concurrency 2 \
         --controlPlaneAuthPolicy NONE \
         --statusPort 15020 \
-        --applicationPorts 8080,8079,8088 \
         --controlPlaneBootstrap=false
 
 }

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -145,10 +145,6 @@ spec:
           - --envoyAccessLogServiceAddress
           - {{ .Values.global.proxy.envoyAccessLogService.host }}:{{ .Values.global.proxy.envoyAccessLogService.port }}
         {{- end }}
-        {{- if $gateway.applicationPorts }}
-          - --applicationPorts
-          - "{{ $gateway.applicationPorts }}"
-        {{- end }}
           - --proxyAdminPort
           - "15000"
           - --statusPort

--- a/gateways/istio-ingress/values.yaml
+++ b/gateways/istio-ingress/values.yaml
@@ -131,14 +131,6 @@ gateways:
     certificates: false
     tls: false
 
-    # Ports to explicitly check for readiness. If configured, the readiness check will expect a
-    # listener on these ports. A comma separated list is expected, such as "80,443".
-    #
-    # Warning: If you do not have a gateway configured for the ports provided, this check will always
-    # fail. This is intended for use cases where you always expect to have a listener on the port,
-    # such as 80 or 443 in typical setups.
-    applicationPorts: ""
-
     # Telemetry addon gateways example config
     telemetry_addon_gateways:
       tracing_gateway:

--- a/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/istio-control/istio-autoinject/files/injection-template.yaml
@@ -156,8 +156,6 @@ template: |
   {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
     - --statusPort
     - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
-    - --applicationPorts
-    - "{{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/applicationPorts` (applicationPorts .Spec.Containers) }}"
   {{- end }}
   {{- if .Values.global.trustDomain }}
     - --trust-domain={{ .Values.global.trustDomain }}
@@ -221,8 +219,6 @@ template: |
       value: "{{ .Values.global.sds.enabled }}"
     - name: ISTIO_META_INTERCEPTION_MODE
       value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-    - name: ISTIO_META_INCLUDE_INBOUND_PORTS
-      value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
     {{- if .Values.global.network }}
     - name: ISTIO_META_NETWORK
       value: "{{ .Values.global.network }}"

--- a/kustomize/default/istio-autoinject.gen.yaml
+++ b/kustomize/default/istio-autoinject.gen.yaml
@@ -258,8 +258,6 @@ data:
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
-        - --applicationPorts
-        - "{{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/applicationPorts` (applicationPorts .Spec.Containers) }}"
       {{- end }}
       {{- if .Values.global.trustDomain }}
         - --trust-domain={{ .Values.global.trustDomain }}
@@ -302,8 +300,6 @@ data:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
-          value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
         {{- if .Values.global.network }}
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.network }}"

--- a/test/demo/inject-allns.gen.yaml
+++ b/test/demo/inject-allns.gen.yaml
@@ -238,8 +238,6 @@ data:
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"
-        - --applicationPorts
-        - "{{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/applicationPorts` (applicationPorts .Spec.Containers) }}"
       {{- end }}
       {{- if .Values.global.trustDomain }}
         - --trust-domain={{ .Values.global.trustDomain }}
@@ -282,8 +280,6 @@ data:
               fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
-          value: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (applicationPorts .Spec.Containers) }}"
         {{- if .Values.global.network }}
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.network }}"


### PR DESCRIPTION
This should fix the test fail of https://github.com/istio/istio/issues/18351, the `applicationPort` is removed in https://github.com/istio/istio/pull/17986.



