### PR TITLE
Fix mtls Destinationrules

### DIFF
--- a/istio-telemetry/prometheus-operator/templates/prometheus.yaml
+++ b/istio-telemetry/prometheus-operator/templates/prometheus.yaml
@@ -83,18 +83,7 @@ metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
 spec:
-  host: prometheus.{{ .Release.Namespace }}
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: prometheus-full
-  namespace: {{ .Release.Namespace }}
-spec:
-  host: prometheus.{{ .Release.Namespace }}.svc.cluster.local
+  host: prometheus
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/istio-telemetry/prometheus/templates/destination-rule.yaml
+++ b/istio-telemetry/prometheus/templates/destination-rule.yaml
@@ -1,21 +1,10 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: prometheys
+  name: prometheus
   namespace: {{ .Release.Namespace }}
 spec:
-  host: prometheus.{{ .Release.Namespace }}
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: prometheus-full
-  namespace: {{ .Release.Namespace }}
-spec:
-  host: prometheus.{{ .Release.Namespace }}.svc.cluster.local
+  host: prometheus
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/kustomize/default/istio-prometheus.gen.yaml
+++ b/kustomize/default/istio-prometheus.gen.yaml
@@ -449,21 +449,10 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: prometheys
+  name: prometheus
   namespace: istio-system
 spec:
-  host: prometheus.istio-system
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: prometheus-full
-  namespace: istio-system
-spec:
-  host: prometheus.istio-system.svc.cluster.local
+  host: prometheus
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/test/demo/prometheus.gen.yaml
+++ b/test/demo/prometheus.gen.yaml
@@ -449,21 +449,10 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: prometheys
+  name: prometheus
   namespace: istio-system
 spec:
-  host: prometheus.istio-system
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: prometheus-full
-  namespace: istio-system
-spec:
-  host: prometheus.istio-system.svc.cluster.local
+  host: prometheus
   trafficPolicy:
     tls:
       mode: DISABLE


### PR DESCRIPTION
These are not being applied properly, so cannot access telemetry
components when mtls is enabled