### PR TITLE
[release-1.4] CNI: Use global hub & tag by default (#482)

### DIFF
--- a/istio-cni/templates/daemonset.yaml
+++ b/istio-cni/templates/daemonset.yaml
@@ -52,7 +52,11 @@ spec:
         # This container installs the Istio CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ .Values.cni.hub }}/{{ .Values.cni.image }}:{{ .Values.cni.tag }}
+{{- if contains "/" .Values.cni.image }}
+          image: "{{ .Values.cni.image }}"
+{{- else }}
+          image: "{{ .Values.cni.hub | default .Values.global.hub }}/{{ .Values.cni.image | default "install-cni" }}:{{ .Values.cni.tag | default .Values.global.tag }}"
+{{- end }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
           command: ["/install-cni.sh"]
           env:

--- a/istio-cni/values.yaml
+++ b/istio-cni/values.yaml
@@ -1,6 +1,6 @@
 cni:
-  hub: gcr.io/istio-testing
-  tag: 1.4-dev
+  hub: ""
+  tag: ""
   image: install-cni
   pullPolicy: Always
 


### PR DESCRIPTION
Manual cherry-pick of #482.