### PR TITLE
add permissions to be able to view logs in kiali console

### DIFF
--- a/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - namespaces
       - nodes
       - pods
+      - pods/log
       - services
       - replicationcontrollers
     verbs:
@@ -78,6 +79,7 @@ rules:
       - namespaces
       - nodes
       - pods
+      - pods/log
       - services
       - replicationcontrollers
     verbs:

--- a/test/demo/kiali.gen.yaml
+++ b/test/demo/kiali.gen.yaml
@@ -73,6 +73,7 @@ rules:
       - namespaces
       - nodes
       - pods
+      - pods/log
       - services
       - replicationcontrollers
     verbs:
@@ -138,6 +139,7 @@ rules:
       - namespaces
       - nodes
       - pods
+      - pods/log
       - services
       - replicationcontrollers
     verbs:


### PR DESCRIPTION
Need to add `pods/log` to the kiali roles so kiali can show logs to the user.

closes https://github.com/istio/istio/issues/18650