### PR TITLE
add istio-reader clusterrole to access remote clusters with reduced privileges

### DIFF
--- a/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -44,4 +44,24 @@ rules:
     - "certificatesigningrequests/status"
   verbs: ["update", "create", "get", "delete"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-reader-{{ .Release.Namespace }}
+  labels:
+    app: istio-reader
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - "config.istio.io"
+  - "rbac.istio.io"
+  - "security.istio.io"
+  - "networking.istio.io"
+  - "authentication.istio.io"
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers"]
+  verbs: ["get", "list", "watch"]
+---
 {{ end }}

--- a/kustomize/default/istio-discovery.gen.yaml
+++ b/kustomize/default/istio-discovery.gen.yaml
@@ -404,6 +404,26 @@ rules:
     - "certificatesigningrequests/status"
   verbs: ["update", "create", "get", "delete"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-reader-istio-system
+  labels:
+    app: istio-reader
+    release: istio-system-istio
+rules:
+- apiGroups:
+  - "config.istio.io"
+  - "rbac.istio.io"
+  - "security.istio.io"
+  - "networking.istio.io"
+  - "authentication.istio.io"
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers"]
+  verbs: ["get", "list", "watch"]
+---
 
 
 ---

--- a/kustomize/minimal/discovery.gen.yaml
+++ b/kustomize/minimal/discovery.gen.yaml
@@ -402,6 +402,26 @@ rules:
     - "certificatesigningrequests/status"
   verbs: ["update", "create", "get", "delete"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-reader-istio-system
+  labels:
+    app: istio-reader
+    release: istio-system-istio-discovery
+rules:
+- apiGroups:
+  - "config.istio.io"
+  - "rbac.istio.io"
+  - "security.istio.io"
+  - "networking.istio.io"
+  - "authentication.istio.io"
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers"]
+  verbs: ["get", "list", "watch"]
+---
 
 
 ---

--- a/test/demo/pilot.gen.yaml
+++ b/test/demo/pilot.gen.yaml
@@ -404,6 +404,26 @@ rules:
     - "certificatesigningrequests/status"
   verbs: ["update", "create", "get", "delete"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-reader-istio-system
+  labels:
+    app: istio-reader
+    release: istio-system-istio
+rules:
+- apiGroups:
+  - "config.istio.io"
+  - "rbac.istio.io"
+  - "security.istio.io"
+  - "networking.istio.io"
+  - "authentication.istio.io"
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers"]
+  verbs: ["get", "list", "watch"]
+---
 
 
 ---


### PR DESCRIPTION
This also fixes an issue where mixer doesn't have sufficient access to
read replicationcontrollers in remote clusters.