### PR TITLE
[kiali] update to Kiali v1.9

### DIFF
--- a/istio-telemetry/kiali/Chart.yaml
+++ b/istio-telemetry/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
 name: kiali
-version: 1.4.0
-appVersion: 1.4.0
+version: 1.9.0
+appVersion: 1.9.0
 tillerVersion: ">=2.7.2"

--- a/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -63,6 +63,7 @@ rules:
       - monitoringdashboards
     verbs:
       - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/istio-telemetry/kiali/templates/configmap.yaml
+++ b/istio-telemetry/kiali/templates/configmap.yaml
@@ -22,6 +22,8 @@ data:
 {{ toYaml . | indent 8 }}
 {{- end }}
 {{- end }}
+    deployment:
+      accessible_namespaces: ['**']
     server:
       port: 20001
 {{- if .Values.kiali.contextPath }}
@@ -34,6 +36,12 @@ data:
         url: {{ .Values.kiali.dashboard.jaegerURL }}
       grafana:
         url: {{ .Values.kiali.dashboard.grafanaURL }}
+      prometheus:
+{{- if .Values.global.prometheusNamespace }}
+        url: http://prometheus.{{ .Values.global.prometheusNamespace }}:9090
+{{ else }}
+        url: http://prometheus:9090
+{{- end }}
 {{- if .Values.kiali.security.enabled }}
     identity:
       cert_file: {{ .Values.kiali.security.cert_file }}

--- a/istio-telemetry/kiali/templates/deployment.yaml
+++ b/istio-telemetry/kiali/templates/deployment.yaml
@@ -60,16 +60,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: PROMETHEUS_SERVICE_URL
-          {{- if .Values.global.prometheusNamespace }}
-          value: http://prometheus.{{ .Values.global.prometheusNamespace }}:9090
-          {{ else }}
-          value: http://prometheus:9090
-          {{- end }}
-{{- if .Values.kiali.contextPath }}
-        - name: SERVER_WEB_ROOT
-          value: {{ .Values.kiali.contextPath }}
-{{- end }}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/istio-telemetry/kiali/values.yaml
+++ b/istio-telemetry/kiali/values.yaml
@@ -4,8 +4,8 @@
 kiali:
   enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
   replicaCount: 1
-  hub: docker.io/kiali
-  tag: v1.4.2
+  hub: quay.io/kiali
+  tag: v1.9
   image: kiali
   contextPath: /kiali # The root context path to access the Kiali UI.
   nodeSelector: {}

--- a/test/demo/kiali.gen.yaml
+++ b/test/demo/kiali.gen.yaml
@@ -34,6 +34,8 @@ data:
     istio_namespace: istio-system
     auth:
       strategy: login
+    deployment:
+      accessible_namespaces: ['**']
     server:
       port: 20001
       web_root: /kiali
@@ -44,6 +46,9 @@ data:
         url: 
       grafana:
         url: 
+      prometheus:
+        url: http://prometheus.istio-system:9090
+
 
 ---
 # Source: kiali/templates/serviceaccount.yaml
@@ -123,6 +128,7 @@ rules:
       - monitoringdashboards
     verbs:
       - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -254,7 +260,7 @@ spec:
     spec:
       serviceAccountName: kiali-service-account
       containers:
-      - image: "docker.io/kiali/kiali:v1.4.2"
+      - image: "quay.io/kiali/kiali:v1.9"
         imagePullPolicy: Always
         name: kiali
         command:
@@ -282,11 +288,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: PROMETHEUS_SERVICE_URL
-          value: http://prometheus.istio-system:9090
-          
-        - name: SERVER_WEB_ROOT
-          value: /kiali
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"


### PR DESCRIPTION
This moves the istio/installer charts to use Kiali v1.9.

Note that this uses `quay.io` repo just like our older helm chart did [as you see here](https://github.com/istio/istio/blob/1.4.0-beta.2/install/kubernetes/helm/istio/charts/kiali/values.yaml#L6). 

Note also that, just as the older helm chart did [as you see here](https://github.com/istio/istio/blob/1.4.0-beta.2/install/kubernetes/helm/istio/charts/kiali/values.yaml#L8), this pulls in the major.minor version (v1.9) leaving the ability for this to pull in z-stream patch versions as they become available. Kiali distributes patches/bug fixes and moves its vX.Y quay label to the latest z-stream release ensuring istio users are pulling in the latest patched release in the X.Y line.

cc @jwendell 