### PR TITLE
Fix grafana datasources value

### DIFF
--- a/istio-telemetry/grafana/templates/configmap.yaml
+++ b/istio-telemetry/grafana/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{ $datasources := index .Values.grafana.datasources "datasources.yaml" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,30 +8,12 @@ metadata:
     release: {{ .Release.Name }}
     istio: grafana
 data:
-  datasources.yaml: |-
-    apiVersion: 1
-    datasources:
-    - name: Prometheus
-      type: prometheus
-      orgId: 1
-{{- if .Values.grafana.prometheusNamespace }}
-      url: http://prometheus.{{ .Values.grafana.prometheusNamespace }}:9090
-{{ else }}
-      url: http://prometheus:9090
-{{- end }}
-      access: proxy
-      isDefault: true
-      jsonData:
-        timeInterval: 5s
-      editable: true
-
-{{- if $datasources.datasources }}
-    -
-  {{- range $key, $value := $datasources.datasources }}
-{{ toYaml $value | indent 6 }}
+{{- if .Values.grafana.datasources }}
+  {{- range $key, $value := .Values.grafana.datasources }}
+  {{ $key }}: |
+{{ toYaml $value | indent 4 }}
   {{- end -}}
-{{- end }}
-
+{{- end -}}
 
 {{- if .Values.grafana.dashboardProviders }}
   {{- range $key, $value := .Values.grafana.dashboardProviders }}

--- a/istio-telemetry/grafana/values.yaml
+++ b/istio-telemetry/grafana/values.yaml
@@ -44,15 +44,15 @@ grafana:
     datasources.yaml:
       apiVersion: 1
       datasources:
-      # - name: Prometheus2
-      #   type: prometheus2
-      #   orgId: 2
-      #   url: http://prometheus:9090
-      #   access: proxy
-      #   isDefault: false
-      #   jsonData:
-      #     timeInterval: 5s
-      #   editable: true
+      - name: Prometheus
+        type: prometheus
+        orgId: 1
+        url: http://prometheus:9090
+        access: proxy
+        isDefault: true
+        jsonData:
+          timeInterval: 5s
+        editable: true
 
   dashboardProviders:
     dashboardproviders.yaml:

--- a/kustomize/default/istio-grafana.gen.yaml
+++ b/kustomize/default/istio-grafana.gen.yaml
@@ -13999,7 +13999,6 @@ data:
 
 ---
 # Source: grafana/templates/configmap.yaml
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14010,18 +14009,19 @@ metadata:
     release: istio-system-istio
     istio: grafana
 data:
-  datasources.yaml: |-
+  datasources.yaml: |
     apiVersion: 1
     datasources:
-    - name: Prometheus
-      type: prometheus
-      orgId: 1
-      url: http://prometheus:9090
-      access: proxy
+    - access: proxy
+      editable: true
       isDefault: true
       jsonData:
         timeInterval: 5s
-      editable: true
+      name: Prometheus
+      orgId: 1
+      type: prometheus
+      url: http://prometheus:9090
+    
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:

--- a/test/demo/grafana.gen.yaml
+++ b/test/demo/grafana.gen.yaml
@@ -13999,7 +13999,6 @@ data:
 
 ---
 # Source: grafana/templates/configmap.yaml
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14010,18 +14009,19 @@ metadata:
     release: istio-system-istio
     istio: grafana
 data:
-  datasources.yaml: |-
+  datasources.yaml: |
     apiVersion: 1
     datasources:
-    - name: Prometheus
-      type: prometheus
-      orgId: 1
-      url: http://prometheus:9090
-      access: proxy
+    - access: proxy
+      editable: true
       isDefault: true
       jsonData:
         timeInterval: 5s
-      editable: true
+      name: Prometheus
+      orgId: 1
+      type: prometheus
+      url: http://prometheus:9090
+    
   dashboardproviders.yaml: |
     apiVersion: 1
     providers:


### PR DESCRIPTION
This now directly matches istio/istio.

The problem here is it is impossible to override the default data
source, and you can only have one default, so there are conflicts.