### PR TITLE
[kiali] issue-18798 fix some wrong yaml.

### DIFF
--- a/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ rules:
       - nodes
       - pods
       - pods/log
-      - services
       - replicationcontrollers
+      - services
     verbs:
       - get
       - list
@@ -23,8 +23,8 @@ rules:
   - apiGroups: ["extensions", "apps"]
     resources:
       - deployments
-      - statefulsets
       - replicasets
+      - statefulsets
     verbs:
       - get
       - list
@@ -81,8 +81,8 @@ rules:
       - nodes
       - pods
       - pods/log
-      - services
       - replicationcontrollers
+      - services
     verbs:
       - get
       - list
@@ -90,8 +90,8 @@ rules:
   - apiGroups: ["extensions", "apps"]
     resources:
       - deployments
-      - statefulsets
       - replicasets
+      - statefulsets
     verbs:
       - get
       - list
@@ -127,3 +127,4 @@ rules:
       - monitoringdashboards
     verbs:
       - get
+      - list

--- a/istio-telemetry/kiali/templates/configmap.yaml
+++ b/istio-telemetry/kiali/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
     external_services:
       istio:
         url_service_version: http://istio-pilot.{{ .Values.global.configNamespace }}:8080/version
-      jaeger:
+      tracing:
         url: {{ .Values.kiali.dashboard.jaegerURL }}
       grafana:
         url: {{ .Values.kiali.dashboard.grafanaURL }}

--- a/kustomize/cluster/crds-namespace.gen.yaml
+++ b/kustomize/cluster/crds-namespace.gen.yaml
@@ -1,4 +1,8 @@
 ---
+# Source: base/templates/endpoints.yaml
+
+
+---
 # Source: base/templates/namespaces.yaml
 # To prevent accidental injection into istio control plane namespaces.
 apiVersion: v1
@@ -5236,10 +5240,6 @@ rules:
   resources: ["replicasets"]
   verbs: ["get", "list", "watch"]
 ---
-
-
----
-# Source: base/templates/endpoints.yaml
 
 
 ---

--- a/test/demo/kiali.gen.yaml
+++ b/test/demo/kiali.gen.yaml
@@ -42,7 +42,7 @@ data:
     external_services:
       istio:
         url_service_version: http://istio-pilot.istio-system:8080/version
-      jaeger:
+      tracing:
         url: 
       grafana:
         url: 
@@ -79,8 +79,8 @@ rules:
       - nodes
       - pods
       - pods/log
-      - services
       - replicationcontrollers
+      - services
     verbs:
       - get
       - list
@@ -88,8 +88,8 @@ rules:
   - apiGroups: ["extensions", "apps"]
     resources:
       - deployments
-      - statefulsets
       - replicasets
+      - statefulsets
     verbs:
       - get
       - list
@@ -146,8 +146,8 @@ rules:
       - nodes
       - pods
       - pods/log
-      - services
       - replicationcontrollers
+      - services
     verbs:
       - get
       - list
@@ -155,8 +155,8 @@ rules:
   - apiGroups: ["extensions", "apps"]
     resources:
       - deployments
-      - statefulsets
       - replicasets
+      - statefulsets
     verbs:
       - get
       - list
@@ -192,6 +192,7 @@ rules:
       - monitoringdashboards
     verbs:
       - get
+      - list
 
 ---
 # Source: kiali/templates/clusterrolebinding.yaml


### PR DESCRIPTION
closes https://github.com/istio/istio/issues/18798

Fix some yaml that is incorrect in the kiali charts.

Another (trivial) change is that this alphabetizes a couple settings to make comparison with the old helm charts easier.