### PR TITLE
Sync labels with istio/istio

### DIFF
--- a/gateways/istio-egress/templates/autoscale.yaml
+++ b/gateways/istio-egress/templates/autoscale.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-egressgateway
+    istio: egressgateway
     release: {{ .Release.Name }}
 spec:
   maxReplicas: {{ $gateway.autoscaleMax }}

--- a/gateways/istio-egress/templates/service.yaml
+++ b/gateways/istio-egress/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app: istio-egressgateway
     release: {{ .Release.Name }}
+    istio: egressgateway
 spec:
   type: ClusterIP
   selector:

--- a/gateways/istio-ingress/templates/autoscale.yaml
+++ b/gateways/istio-ingress/templates/autoscale.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-ingressgateway
+    istio: ingressgateway
     release: {{ .Release.Name }}
 spec:
   maxReplicas: {{ $gateway.autoscaleMax }}

--- a/gateways/istio-ingress/templates/service.yaml
+++ b/gateways/istio-ingress/templates/service.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     release: {{ .Release.Name }}
+    istio: ingressgateway
 spec:
 {{- if $gateway.loadBalancerIP }}
   loadBalancerIP: "{{ $gateway.loadBalancerIP }}"

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: {{ .Release.Namespace }}
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: {{ .Release.Name }}
     istio: sidecar-injector
 spec:

--- a/istio-control/istio-autoinject/templates/service.yaml
+++ b/istio-control/istio-autoinject/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: {{ .Release.Namespace }}
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: {{ .Release.Name }}
     istio: sidecar-injector
 spec:

--- a/istio-control/istio-autoinject/templates/serviceaccount.yaml
+++ b/istio-control/istio-autoinject/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: istio-sidecar-injector-service-account
+  name: sidecarInjectorWebhook
   namespace: {{ .Release.Namespace }}
   labels:
     app: sidecar-injector

--- a/istio-control/istio-autoinject/templates/serviceaccount.yaml
+++ b/istio-control/istio-autoinject/templates/serviceaccount.yaml
@@ -7,9 +7,9 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: sidecarInjectorWebhook
+  name: istio-sidecar-injector-service-account
   namespace: {{ .Release.Namespace }}
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: {{ .Release.Name }}
     istio: sidecar-injector

--- a/istio-policy/templates/autoscale.yaml
+++ b/istio-policy/templates/autoscale.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-policy
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-policy
+    app: mixer
     release: {{ .Release.Name }}
 spec:
     maxReplicas: {{ .Values.mixer.policy.autoscaleMax }}

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -19,13 +19,12 @@ spec:
       maxUnavailable: {{ .Values.mixer.policy.rollingMaxUnavailable }}
   selector:
     matchLabels:
-      app: istio-policy
       istio: mixer
       istio-mixer-type: policy
   template:
     metadata:
       labels:
-        app: istio-policy
+        app: policy
         istio: mixer
         istio-mixer-type: policy
       annotations:

--- a/istio-policy/templates/poddisruptionbudget.yaml
+++ b/istio-policy/templates/poddisruptionbudget.yaml
@@ -13,7 +13,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: istio-policy
+      app: policy
       release: {{ .Release.Name }}
       istio: mixer
       istio-mixer-type: policy

--- a/istio-policy/templates/poddisruptionbudget.yaml
+++ b/istio-policy/templates/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-policy
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-policy
+    app: policy
     release: {{ .Release.Name }}
     istio: mixer
     istio-mixer-type: policy

--- a/istio-policy/templates/service.yaml
+++ b/istio-policy/templates/service.yaml
@@ -16,7 +16,8 @@ spec:
   - name: http-policy-monitoring
     port: 15014
   selector:
-    app: istio-policy
+    istio: mixer
+    istio-mixer-type: policy
 {{- if .Values.mixer.policy.sessionAffinityEnabled }}
   sessionAffinity: ClientIP
 {{- end }}

--- a/istio-policy/templates/service.yaml
+++ b/istio-policy/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-policy
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-policy
+    app: mixer
     istio: mixer
     release: {{ .Release.Name }}
 spec:

--- a/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
@@ -5,8 +5,8 @@ metadata:
   name: istio-telemetry
   namespace: {{ .Release.Namespace }}
   labels:
-    release: {{ .Release.Name }}
     app: mixer
+    release: {{ .Release.Name }}
 spec:
     maxReplicas: {{ .Values.mixer.telemetry.autoscaleMax }}
     minReplicas: {{ .Values.mixer.telemetry.autoscaleMin }}

--- a/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
-    app: istio-telemetry
+    app: mixer
 spec:
     maxReplicas: {{ .Values.mixer.telemetry.autoscaleMax }}
     minReplicas: {{ .Values.mixer.telemetry.autoscaleMin }}

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: istio-mixer
     istio: mixer
     release: {{ .Release.Name }}
-    istio-mixer-type: telemetry
 spec:
   replicas: {{ .Values.mixer.telemetry.replicaCount }}
   strategy:

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app: istio-telemetry
+        app: telemetry
         istio: mixer
         istio-mixer-type: telemetry
       annotations:

--- a/istio-telemetry/mixer-telemetry/templates/poddisruptionbudget.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-telemetry
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-telemetry
+    app: telemetry
     release: {{ .Release.Name }}
     istio: mixer
     istio-mixer-type: telemetry

--- a/istio-telemetry/mixer-telemetry/templates/poddisruptionbudget.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/poddisruptionbudget.yaml
@@ -13,7 +13,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: istio-telemetry
+      app: telemetry
       release: {{ .Release.Name }}
       istio: mixer
       istio-mixer-type: telemetry

--- a/istio-telemetry/mixer-telemetry/templates/service.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-telemetry
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-telemetry
+    app: mixer
     istio: mixer
     release: {{ .Release.Name }}
 spec:

--- a/kustomize/citadel/citadel.yaml
+++ b/kustomize/citadel/citadel.yaml
@@ -6,6 +6,7 @@ metadata:
   name: istio-citadel-service-account
   namespace: istio-system
   labels:
+    app: security
     release: istio-system-istio-system-security
 
 ---
@@ -63,7 +64,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio-system-security
 
@@ -87,7 +88,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio-system-security
 
@@ -177,7 +178,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio-system-security
 spec:

--- a/kustomize/cluster/crds-namespace.gen.yaml
+++ b/kustomize/cluster/crds-namespace.gen.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: base/templates/namespaces.yaml
+# To prevent accidental injection into istio control plane namespaces.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    istio-operator-managed: Reconcile
+    istio-injection: disabled
+---
+
+---
 # Source: base/templates/serviceaccount.yaml
 
 apiVersion: v1
@@ -5264,18 +5276,6 @@ subjects:
 ---
 # Source: base/templates/endpoints.yaml
 
-
----
-# Source: base/templates/namespaces.yaml
-# To prevent accidental injection into istio control plane namespaces.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
 
 ---
 # Source: base/templates/services.yaml

--- a/kustomize/cluster/crds-namespace.gen.yaml
+++ b/kustomize/cluster/crds-namespace.gen.yaml
@@ -1,16 +1,4 @@
 ---
-# Source: base/templates/namespaces.yaml
-# To prevent accidental injection into istio control plane namespaces.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
-
----
 # Source: base/templates/serviceaccount.yaml
 
 apiVersion: v1
@@ -5276,6 +5264,18 @@ subjects:
 ---
 # Source: base/templates/endpoints.yaml
 
+
+---
+# Source: base/templates/namespaces.yaml
+# To prevent accidental injection into istio control plane namespaces.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    istio-operator-managed: Reconcile
+    istio-injection: disabled
+---
 
 ---
 # Source: base/templates/services.yaml

--- a/kustomize/default/istio-autoinject.gen.yaml
+++ b/kustomize/default/istio-autoinject.gen.yaml
@@ -482,7 +482,7 @@ data:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-sidecar-injector-service-account
+  name: sidecarInjectorWebhook
   namespace: istio-system
   labels:
     app: sidecar-injector
@@ -535,7 +535,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: istio-system-istio
     istio: sidecar-injector
 spec:
@@ -553,7 +553,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: istio-system-istio
     istio: sidecar-injector
 spec:

--- a/kustomize/default/istio-autoinject.gen.yaml
+++ b/kustomize/default/istio-autoinject.gen.yaml
@@ -482,10 +482,10 @@ data:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sidecarInjectorWebhook
+  name: istio-sidecar-injector-service-account
   namespace: istio-system
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: istio-system-istio
     istio: sidecar-injector
 

--- a/kustomize/default/istio-citadel.gen.yaml
+++ b/kustomize/default/istio-citadel.gen.yaml
@@ -6,6 +6,7 @@ metadata:
   name: istio-citadel-service-account
   namespace: istio-system
   labels:
+    app: security
     release: istio-system-istio
 
 ---
@@ -63,7 +64,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio
 
@@ -87,7 +88,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio
 
@@ -177,7 +178,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio
 spec:

--- a/kustomize/default/istio-ingress.gen.yaml
+++ b/kustomize/default/istio-ingress.gen.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     release: istio-system-istio
+    istio: ingressgateway
 spec:
   type: LoadBalancer
   selector:
@@ -307,6 +308,7 @@ metadata:
   namespace: istio-system
   labels:
     app: istio-ingressgateway
+    istio: ingressgateway
     release: istio-system-istio
 spec:
   maxReplicas: 5

--- a/kustomize/default/istio-telemetry.gen.yaml
+++ b/kustomize/default/istio-telemetry.gen.yaml
@@ -403,7 +403,7 @@ spec:
   template:
     metadata:
       labels:
-        app: istio-telemetry
+        app: telemetry
         istio: mixer
         istio-mixer-type: telemetry
       annotations:
@@ -570,8 +570,8 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
-    release: istio-system-istio
     app: mixer
+    release: istio-system-istio
 spec:
     maxReplicas: 5
     minReplicas: 1
@@ -595,7 +595,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
-    app: istio-telemetry
+    app: telemetry
     release: istio-system-istio
     istio: mixer
     istio-mixer-type: telemetry

--- a/kustomize/default/istio-telemetry.gen.yaml
+++ b/kustomize/default/istio-telemetry.gen.yaml
@@ -361,7 +361,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
-    app: istio-telemetry
+    app: mixer
     istio: mixer
     release: istio-system-istio
 spec:
@@ -390,7 +390,6 @@ metadata:
     app: istio-mixer
     istio: mixer
     release: istio-system-istio
-    istio-mixer-type: telemetry
 spec:
   replicas: 1
   strategy:
@@ -572,7 +571,7 @@ metadata:
   namespace: istio-system
   labels:
     release: istio-system-istio
-    app: istio-telemetry
+    app: mixer
 spec:
     maxReplicas: 5
     minReplicas: 1
@@ -604,7 +603,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: istio-telemetry
+      app: telemetry
       release: istio-system-istio
       istio: mixer
       istio-mixer-type: telemetry

--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-citadel
   namespace: {{ .Release.Namespace }}
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: {{ .Release.Name }}
 

--- a/security/citadel/templates/poddisruptionbudget.yaml
+++ b/security/citadel/templates/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-citadel
   namespace: {{ .Release.Namespace }}
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: {{ .Release.Name }}
 spec:

--- a/security/citadel/templates/service.yaml
+++ b/security/citadel/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: istio-citadel
   namespace: {{ .Release.Namespace }}
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: {{ .Release.Name }}
 

--- a/security/citadel/templates/serviceaccount.yaml
+++ b/security/citadel/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ metadata:
   name: istio-citadel-service-account
   namespace: {{ .Release.Namespace }}
   labels:
+    app: security
     release: {{ .Release.Name }}
   {{- if .Values.global.imagePullSecrets }}
 spec:

--- a/test/demo/citadel.gen.yaml
+++ b/test/demo/citadel.gen.yaml
@@ -6,6 +6,7 @@ metadata:
   name: istio-citadel-service-account
   namespace: istio-system
   labels:
+    app: security
     release: istio-system-istio
 
 ---
@@ -63,7 +64,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio
 
@@ -87,7 +88,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
-    app: citadel
+    app: security
     istio: citadel
     release: istio-system-istio
 

--- a/test/demo/egress.gen.yaml
+++ b/test/demo/egress.gen.yaml
@@ -47,6 +47,7 @@ metadata:
   labels:
     app: istio-egressgateway
     release: istio-system-istio
+    istio: egressgateway
 spec:
   type: ClusterIP
   selector:

--- a/test/demo/ingress.gen.yaml
+++ b/test/demo/ingress.gen.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: istio-ingressgateway
     release: istio-system-istio
+    istio: ingressgateway
 spec:
   type: LoadBalancer
   selector:

--- a/test/demo/inject-allns.gen.yaml
+++ b/test/demo/inject-allns.gen.yaml
@@ -482,7 +482,7 @@ data:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-sidecar-injector-service-account
+  name: sidecarInjectorWebhook
   namespace: istio-system
   labels:
     app: sidecar-injector
@@ -535,7 +535,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: istio-system-istio
     istio: sidecar-injector
 spec:
@@ -553,7 +553,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: istio-system-istio
     istio: sidecar-injector
 spec:

--- a/test/demo/inject-allns.gen.yaml
+++ b/test/demo/inject-allns.gen.yaml
@@ -482,10 +482,10 @@ data:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sidecarInjectorWebhook
+  name: istio-sidecar-injector-service-account
   namespace: istio-system
   labels:
-    app: sidecar-injector
+    app: sidecarInjectorWebhook
     release: istio-system-istio
     istio: sidecar-injector
 

--- a/test/demo/policy.gen.yaml
+++ b/test/demo/policy.gen.yaml
@@ -61,7 +61,7 @@ metadata:
   name: istio-policy
   namespace: istio-system
   labels:
-    app: istio-policy
+    app: mixer
     istio: mixer
     release: istio-system-istio
 spec:

--- a/test/demo/policy.gen.yaml
+++ b/test/demo/policy.gen.yaml
@@ -73,7 +73,8 @@ spec:
   - name: http-policy-monitoring
     port: 15014
   selector:
-    app: istio-policy
+    istio: mixer
+    istio-mixer-type: policy
 ---
 
 
@@ -96,13 +97,12 @@ spec:
       maxUnavailable: 25%
   selector:
     matchLabels:
-      app: istio-policy
       istio: mixer
       istio-mixer-type: policy
   template:
     metadata:
       labels:
-        app: istio-policy
+        app: policy
         istio: mixer
         istio-mixer-type: policy
       annotations:

--- a/test/demo/telemetry.gen.yaml
+++ b/test/demo/telemetry.gen.yaml
@@ -403,7 +403,7 @@ spec:
   template:
     metadata:
       labels:
-        app: istio-telemetry
+        app: telemetry
         istio: mixer
         istio-mixer-type: telemetry
       annotations:
@@ -570,8 +570,8 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
-    release: istio-system-istio
     app: mixer
+    release: istio-system-istio
 spec:
     maxReplicas: 5
     minReplicas: 1

--- a/test/demo/telemetry.gen.yaml
+++ b/test/demo/telemetry.gen.yaml
@@ -361,7 +361,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
-    app: istio-telemetry
+    app: mixer
     istio: mixer
     release: istio-system-istio
 spec:
@@ -390,7 +390,6 @@ metadata:
     app: istio-mixer
     istio: mixer
     release: istio-system-istio
-    istio-mixer-type: telemetry
 spec:
   replicas: 1
   strategy:
@@ -572,7 +571,7 @@ metadata:
   namespace: istio-system
   labels:
     release: istio-system-istio
-    app: istio-telemetry
+    app: mixer
 spec:
     maxReplicas: 5
     minReplicas: 1


### PR DESCRIPTION
I don't fully understand the details of it, but Kubernetes gets mad when
you change labels sometimes, our tools depend on some labels (like
istioctl), and users may have tools/scripts that do as well. For
consistency, make these the same as istio/istio

Fixes https://github.com/istio/istio/issues/18773