### PR TITLE
Add the port number back for meshexpansion-vs-pilot

### DIFF
--- a/gateways/istio-ingress/templates/meshexpansion.yaml
+++ b/gateways/istio-ingress/templates/meshexpansion.yaml
@@ -1,4 +1,3 @@
-{{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
 {{- if .Values.global.meshExpansion.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -39,7 +38,7 @@ spec:
   - meshexpansion-gateway
   tcp:
   - match:
-    - port: {{ $gateway.externalPort }}
+    - port: 15011
     route:
     - destination:
         host: istio-pilot.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}


### PR DESCRIPTION
Fix: https://github.com/istio/istio/issues/18873

Use the port number as what is currently used in old charts:
https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/pilot/templates/meshexpansion.yaml#L60