### PR TITLE
Set stream_idle_timeout for pilot/galley listeners

### DIFF
--- a/istio-control/istio-config/templates/configmap-envoy.yaml
+++ b/istio-control/istio-config/templates/configmap-envoy.yaml
@@ -48,6 +48,7 @@ data:
             config:
               codec_type: HTTP2
               stat_prefix: "15010"
+              stream_idle_timeout: 0s
               http2_protocol_options:
                 max_concurrent_streams: 1073741824
 

--- a/istio-control/istio-discovery/templates/configmap-envoy.yaml
+++ b/istio-control/istio-discovery/templates/configmap-envoy.yaml
@@ -81,6 +81,7 @@ data:
             config:
               codec_type: HTTP2
               stat_prefix: "15011"
+              stream_idle_timeout: 0s
               http2_protocol_options:
                 max_concurrent_streams: 1073741824
 
@@ -139,6 +140,7 @@ data:
                 config:
                   codec_type: HTTP2
                   stat_prefix: "15019"
+                  stream_idle_timeout: 0s
                   http2_protocol_options:
                     max_concurrent_streams: 1073741824
 

--- a/istio-telemetry/mixer-telemetry/templates/configmap-envoy.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/configmap-envoy.yaml
@@ -270,6 +270,7 @@ data:
                 config:
                   codec_type: HTTP2
                   stat_prefix: "15019"
+                  stream_idle_timeout: 0s
                   http2_protocol_options:
                     max_concurrent_streams: 1073741824
 


### PR DESCRIPTION
See https://github.com/istio/istio/pull/19043 for prior discussion.

Both pilot and galley set max client ages in order to promote rebalancing, but the default `stream_idle_timeout` value of `5m` is lower than the default max client age of `30m`. This is causing reconnects to occur more frequently than intended. This change disables the idle timeout entirely, giving control back to pilot and galley over when the client connections are killed.

Mixer does not seem to set the max client age, so the `stream_idle_timeout` is only being set for the static listener for outbound connections to galley.