### PR TITLE
Resolution for a regression

### DIFF
--- a/istio-telemetry/tracing/templates/service.yaml
+++ b/istio-telemetry/tracing/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   ports:
-    - port: {{ .Values.tracing.service.externalPort }}
+    - port: {{ .Values.tracing.zipkin.queryPort }}
       targetPort: {{ .Values.tracing.zipkin.queryPort }}
       protocol: TCP
       name: {{ .Values.tracing.service.name }}

--- a/istio-telemetry/tracing/values.yaml
+++ b/istio-telemetry/tracing/values.yaml
@@ -87,7 +87,7 @@ tracing:
     annotations: {}
     name: http-query
     type: ClusterIP
-    externalPort: 9411
+    externalPort: 80
 
   ingress:
     enabled: false


### PR DESCRIPTION
Fixes: #19227

This PR mirrors: https://github.com/istio/istio/pull/19231

I am not confident this change is correct, however, it does revert back to the original
1.3 behavior. I don't understand why we want two services (zipkin and tracing). Should not
tracing be sufficient?

If we must retain zipkin and we want tracing to run on port 9411 (vs what it has been running
on which is port 80...) zipkin must run on some other port.