### PR TITLE
Fix DataDog traces are not being sent bug

### DIFF
--- a/istio-control/istio-autoinject/templates/configmap.yaml
+++ b/istio-control/istio-autoinject/templates/configmap.yaml
@@ -66,6 +66,11 @@ data:
         {{- else }}
           address: zipkin.{{ .Values.global.telemetryNamespace }}:9411
         {{- end }}
+      {{- else if eq .Values.global.proxy.tracer "datadog" }}
+      tracing:
+        datadog:
+          # Address of the DataDog Agent
+          address: {{ .Values.global.tracer.datadog.address }}
       {{- end }}
 
     {{- if .Values.global.controlPlaneSecurityEnabled }}


### PR DESCRIPTION
Currently proxies are not able to send DataDog traces, and I noticed that the agent address was not properly set on the proxy side. 

This PR would solve that issue. 

Signed-off-by: Jon Yucel <jon.yucel@getcruise.com>