### PR TITLE
more granular stackdriver control with logging.enabled and metrics.enabled flags

### DIFF
--- a/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/stackdriver.yaml
@@ -24,6 +24,7 @@ spec:
     {{- if .Values.mixer.adapters.stackdriver.auth.appCredentials }}
     appCredentials: {{ .Values.mixer.adapters.stackdriver.auth.appCredentials }}
     {{- end }}
+    {{- if .Values.mixer.adapters.stackdriver.metrics.enabled }}
     metricInfo:
       server-request-count.instance.{{ .Release.Namespace }}:
         # Due to a bug in gogoproto deserialization, Enums in maps must be
@@ -107,6 +108,8 @@ spec:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/client/sent_bytes_count"
+    {{- end }}
+    {{- if .Values.mixer.adapters.stackdriver.logging.enabled }}
     logInfo:
       server-accesslog-stackdriver.instance.{{ .Release.Namespace }}:
         labelNames:
@@ -176,7 +179,9 @@ spec:
         - sent_bytes
         - total_received_bytes
         - total_sent_bytes
+      {{- end }}
 ---
+{{- if .Values.mixer.adapters.stackdriver.metrics.enabled }}
 #################################################
 ############## Metric Config ####################
 #################################################
@@ -705,7 +710,9 @@ spec:
       namespace_name: source.workload.namespace | "unknown"
       location: '""'
       pod_name: source.name | "unknown"
+{{- end }}
 ---
+{{- if .Values.mixer.adapters.stackdriver.logging.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: instance
 metadata:
@@ -845,6 +852,7 @@ spec:
   - handler: stackdriver
     instances:
     - server-tcp-accesslog-stackdriver
+{{- end }}
 ---
 {{- if .Values.mixer.adapters.stackdriver.tracer.enabled }}
 apiVersion: "config.istio.io/v1alpha2"

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -31,10 +31,10 @@ mixer:
         enabled: false
 
       logging:
-        enabled: false
+        enabled: true
 
       metrics:
-        enabled: false
+        enabled: true
 
     # Setting this to false sets the useAdapterCRDs mixer startup argument to false
     useAdapterCRDs: false

--- a/istio-telemetry/mixer-telemetry/values.yaml
+++ b/istio-telemetry/mixer-telemetry/values.yaml
@@ -30,6 +30,12 @@ mixer:
       contextGraph:
         enabled: false
 
+      logging:
+        enabled: false
+
+      metrics:
+        enabled: false
+
     # Setting this to false sets the useAdapterCRDs mixer startup argument to false
     useAdapterCRDs: false
 


### PR DESCRIPTION
This PR will add more granular control over Stackdriver and will allow having opt-in logging and metrics through logging.enabled and metrics.enabled flags. 

Signed-off-by: Jon Yucel <jon.yucel@getcruise.com>