### PR TITLE
Add scrape target for istio-sidecar-injector

### DIFF
--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -29,7 +29,7 @@ spec:
   jobLabel: istio
   selector:
     matchExpressions:
-      - {key: istio, operator: In, values: [mixer,pilot,galley,citadel]}
+      - {key: istio, operator: In, values: [mixer,pilot,galley,citadel,sidecar-injector]}
   namespaceSelector:
     any: true
   endpoints:

--- a/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/istio-telemetry/prometheus/templates/configmap.yaml
@@ -110,6 +110,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - {{ .Release.Namespace }}
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:


### PR DESCRIPTION
This PR adds a scrape target for the `istio-sidecar-injector` in order to monitor the `istio-sidecar-injector` (which also provides metrics).

See also: https://github.com/istio/istio/pull/19301