### PR TITLE
[release-1.4] Fix sds static config for Pilot, Galley

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -430,9 +430,9 @@ global:
     enabled: false
     udsPath: ""
     # The JWT token for SDS and the aud field of such JWT. See RFC 7519, section 4.1.3.
-    # When a CSR is sent from Citadel Agent to the CA (e.g. Citadel), this aud is to make sure the
-    # JWT is intended for the CA.
     token:
+      # When a CSR is sent from Citadel Agent to the CA (e.g. Citadel), this aud is to make sure the
+      # JWT is intended for the CA.
       aud: istio-ca
 
 

--- a/istio-control/istio-config/templates/configmap-envoy.yaml
+++ b/istio-control/istio-config/templates/configmap-envoy.yaml
@@ -74,6 +74,54 @@ data:
                     route:
                       cluster: in.9901
                       timeout: 0.000s
+        {{- if .Values.global.sds.enabled }}
+          tls_context:
+            common_tls_context:
+              alpn_protocols:
+              - h2
+              tls_certificate_sds_secret_configs:
+              - name: default
+                sds_config:
+                  api_config_source:
+                    api_type: GRPC
+                    grpc_services:
+                    - google_grpc:
+                        target_uri: {{ .Values.global.sds.udsPath }}
+                        channel_credentials:
+                          local_credentials: {}
+                        call_credentials:
+                        - from_plugin:
+                            name: envoy.grpc_credentials.file_based_metadata
+                            config:
+                              header_key: istio_sds_credentials_header-bin
+                              secret_data:
+                                filename: /var/run/secrets/tokens/istio-token
+                        credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                        stat_prefix: sdsstat
+              combined_validation_context:
+                default_validation_context:
+                  verify_subject_alt_name: []
+                validation_context_sds_secret_config:
+                  name: ROOTCA
+                  sds_config:
+                    api_config_source:
+                      api_type: GRPC
+                      grpc_services:
+                      - google_grpc:
+                          target_uri: {{ .Values.global.sds.udsPath }}
+                          channel_credentials:
+                            local_credentials: {}
+                          call_credentials:
+                          - from_plugin:
+                              name: envoy.grpc_credentials.file_based_metadata
+                              config:
+                                header_key: istio_sds_credentials_header-bin
+                                secret_data:
+                                  filename: /var/run/secrets/tokens/istio-token
+                          credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                          stat_prefix: sdsstat
+            require_client_certificate: true
+        {{- else }}
           tls_context:
             common_tls_context:
               alpn_protocols:
@@ -87,5 +135,6 @@ data:
                 trusted_ca:
                   filename: /etc/certs/root-cert.pem
             require_client_certificate: true
+        {{- end }}
 {{- end }}
 ---

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -181,9 +181,28 @@ spec:
             readOnly: true
           - name: envoy-config
             mountPath: /var/lib/istio/galley/envoy
+          {{- if .Values.global.sds.enabled }}
+          - name: sds-uds-path
+            mountPath: /var/run/sds
+            readOnly: true
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+          {{- end }}
 {{- end }}
 
       volumes:
+      {{- if .Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds
+        name: sds-uds-path
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ .Values.global.sds.token.aud }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
   {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
       - name: istio-certs
         secret:

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -176,9 +176,6 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
           volumeMounts:
-          - name: istio-certs
-            mountPath: /etc/certs
-            readOnly: true
           - name: envoy-config
             mountPath: /var/lib/istio/galley/envoy
           {{- if .Values.global.sds.enabled }}
@@ -187,10 +184,18 @@ spec:
             readOnly: true
           - name: istio-token
             mountPath: /var/run/secrets/tokens
+          {{ else }}
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
           {{- end }}
 {{- end }}
 
       volumes:
+  {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-galley-service-account
       {{- if .Values.global.sds.enabled }}
       - hostPath:
           path: /var/run/sds
@@ -203,10 +208,6 @@ spec:
               expirationSeconds: 43200
               path: istio-token
       {{- end }}
-  {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
-      - name: istio-certs
-        secret:
-          secretName: istio.istio-galley-service-account
   {{- end }}
   {{- if .Values.global.certificates }}
       - name: dnscerts

--- a/istio-control/istio-discovery/templates/configmap-envoy.yaml
+++ b/istio-control/istio-discovery/templates/configmap-envoy.yaml
@@ -47,7 +47,57 @@ data:
               max_pending_requests: 100000
               max_requests: 100000
               max_retries: 3
-
+        hosts:
+          - socket_address:
+              address: istio-galley.{{ .Values.global.configNamespace }}
+              port_value: 15019
+      {{- if .Values.global.controlPlaneSecurityEnabled }}
+      {{- if .Values.global.sds.enabled }}
+        tls_context:
+          common_tls_context:
+            tls_certificate_sds_secret_configs:
+            - name: default
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: {{ .Values.global.sds.udsPath }}
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: /var/run/secrets/tokens/istio-token
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+            combined_validation_context:
+              default_validation_context:
+                verify_subject_alt_name:
+                - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.configNamespace }}/sa/istio-galley-service-account
+              validation_context_sds_secret_config:
+                name: ROOTCA
+                sds_config:
+                  api_config_source:
+                    api_type: GRPC
+                    grpc_services:
+                    - google_grpc:
+                        target_uri: {{ .Values.global.sds.udsPath }}
+                        channel_credentials:
+                          local_credentials: {}
+                        call_credentials:
+                        - from_plugin:
+                            name: envoy.grpc_credentials.file_based_metadata
+                            config:
+                              header_key: istio_sds_credentials_header-bin
+                              secret_data:
+                                filename: /var/run/secrets/tokens/istio-token
+                        credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                        stat_prefix: sdsstat
+      {{- else }}
         tls_context:
           common_tls_context:
             tls_certificates:
@@ -60,12 +110,8 @@ data:
                 filename: /etc/certs/root-cert.pem
               verify_subject_alt_name:
               - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.configNamespace }}/sa/istio-galley-service-account
-
-        hosts:
-          - socket_address:
-              address: istio-galley.{{ .Values.global.configNamespace }}
-              port_value: 15019
-
+      {{- end }}
+      {{- end }}
 
       listeners:
       - name: "in.15011"
@@ -110,21 +156,68 @@ data:
                     decorator:
                       operation: xDS
 
+        {{- if .Values.global.sds.enabled }}
           tls_context:
-            require_client_certificate: true
             common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/certs/root-cert.pem
-
               alpn_protocols:
               - h2
-
+              tls_certificate_sds_secret_configs:
+              - name: default
+                sds_config:
+                  api_config_source:
+                    api_type: GRPC
+                    grpc_services:
+                    - google_grpc:
+                        target_uri: {{ .Values.global.sds.udsPath }}
+                        channel_credentials:
+                          local_credentials: {}
+                        call_credentials:
+                        - from_plugin:
+                            name: envoy.grpc_credentials.file_based_metadata
+                            config:
+                              header_key: istio_sds_credentials_header-bin
+                              secret_data:
+                                filename: /var/run/secrets/tokens/istio-token
+                        credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                        stat_prefix: sdsstat
+              combined_validation_context:
+                default_validation_context:
+                  verify_subject_alt_name: []
+                validation_context_sds_secret_config:
+                  name: ROOTCA
+                  sds_config:
+                    api_config_source:
+                      api_type: GRPC
+                      grpc_services:
+                      - google_grpc:
+                          target_uri: {{ .Values.global.sds.udsPath }}
+                          channel_credentials:
+                            local_credentials: {}
+                          call_credentials:
+                          - from_plugin:
+                              name: envoy.grpc_credentials.file_based_metadata
+                              config:
+                                header_key: istio_sds_credentials_header-bin
+                                secret_data:
+                                  filename: /var/run/secrets/tokens/istio-token
+                          credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                          stat_prefix: sdsstat
+            require_client_certificate: true
+        {{- else }}
+          tls_context:
+            common_tls_context:
+              alpn_protocols:
+              - h2
               tls_certificates:
               - certificate_chain:
                   filename: /etc/certs/cert-chain.pem
                 private_key:
                   filename: /etc/certs/key.pem
+              validation_context:
+                trusted_ca:
+                  filename: /etc/certs/root-cert.pem
+            require_client_certificate: true
+        {{- end }}
 
 
       # Manual 'whitebox' mode

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -197,9 +197,6 @@ spec:
 {{ toYaml .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           volumeMounts:
-          - name: istio-certs
-            mountPath: /etc/certs
-            readOnly: true
           - name: pilot-envoy-config
             mountPath: /var/lib/envoy
           {{- if .Values.global.sds.enabled }}
@@ -208,6 +205,10 @@ spec:
             readOnly: true
           - name: istio-token
             mountPath: /var/run/secrets/tokens
+          {{ else }}
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
           {{- end }}
 {{- end }}
       volumes:
@@ -222,6 +223,11 @@ spec:
               audience: {{ .Values.global.sds.token.aud }}
               expirationSeconds: 43200
               path: istio-token
+      {{ else }}
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-pilot-service-account
+          optional: true
       {{- end }}
       - name: config-volume
         configMap:
@@ -229,12 +235,6 @@ spec:
       - name: pilot-envoy-config
         configMap:
           name: pilot-envoy-config{{ .Values.version }}
-  {{- if .Values.global.controlPlaneSecurityEnabled}}
-      - name: istio-certs
-        secret:
-          secretName: istio.istio-pilot-service-account
-          optional: true
-  {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}

--- a/istio-policy/templates/configmap-envoy.yaml
+++ b/istio-policy/templates/configmap-envoy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: telemetry-envoy-config
+  name: policy-envoy-config
   labels:
     release: {{ .Release.Name }}
 data:
@@ -44,8 +44,7 @@ data:
             address: 127.0.0.1
             port_value: 15000
 
-      - name: inbound_9092
-        circuit_breakers:
+      - circuit_breakers:
           thresholds:
           - max_connections: 100000
             max_pending_requests: 100000
@@ -56,6 +55,85 @@ data:
         - pipe:
             path: /sock/mixer.socket
         http2_protocol_options: {}
+        name: inbound_9092
+
+      - circuit_breakers:
+          thresholds:
+          - max_connections: 100000
+            max_pending_requests: 100000
+            max_requests: 100000
+            max_retries: 3
+        connect_timeout: 1.000s
+        hosts:
+        - socket_address:
+            address: istio-telemetry
+            port_value: 15004
+        http2_protocol_options: {}
+        name: mixer_report_server
+
+    {{- if .Values.global.controlPlaneSecurityEnabled }}
+    {{- if .Values.global.sds.enabled }}
+        tls_context:
+          common_tls_context:
+            tls_certificate_sds_secret_configs:
+            - name: default
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - google_grpc:
+                      target_uri: {{ .Values.global.sds.udsPath }}
+                      channel_credentials:
+                        local_credentials: {}
+                      call_credentials:
+                      - from_plugin:
+                          name: envoy.grpc_credentials.file_based_metadata
+                          config:
+                            header_key: istio_sds_credentials_header-bin
+                            secret_data:
+                              filename: /var/run/secrets/tokens/istio-token
+                      credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                      stat_prefix: sdsstat
+            combined_validation_context:
+              default_validation_context:
+                verify_subject_alt_name:
+                - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.configNamespace }}/sa/istio-mixer-service-account
+              validation_context_sds_secret_config:
+                name: ROOTCA
+                sds_config:
+                  api_config_source:
+                    api_type: GRPC
+                    grpc_services:
+                    - google_grpc:
+                        target_uri: {{ .Values.global.sds.udsPath }}
+                        channel_credentials:
+                          local_credentials: {}
+                        call_credentials:
+                        - from_plugin:
+                            name: envoy.grpc_credentials.file_based_metadata
+                            config:
+                              header_key: istio_sds_credentials_header-bin
+                              secret_data:
+                                filename: /var/run/secrets/tokens/istio-token
+                        credentials_factory_name: envoy.grpc_credentials.file_based_metadata
+                        stat_prefix: sdsstat
+    {{- else }}
+        tls_context:
+          common_tls_context:
+            tls_certificates:
+            - certificate_chain:
+                filename: /etc/certs/cert-chain.pem
+              private_key:
+                filename: /etc/certs/key.pem
+            validation_context:
+              trusted_ca:
+                filename: /etc/certs/root-cert.pem
+              verify_subject_alt_name:
+              - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.configNamespace }}/sa/istio-mixer-service-account
+    {{- end }}
+    {{- end }}
+        type: STRICT_DNS
+        dns_lookup_family: V4_ONLY
 
       - name: out.galley.15019
         http2_protocol_options: {}
@@ -174,9 +252,9 @@ data:
               generate_request_id: true
               http_filters:
               - config:
-                  default_destination_service: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+                  default_destination_service: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
                   service_configs:
-                    istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}:
+                    istio-policy.{{ .Release.Namespace }}.svc.cluster.local:
                       disable_check_calls: true
     {{"{{"}}- if .DisableReportCalls {{"}}"}}
                       disable_report_calls: true
@@ -184,11 +262,11 @@ data:
                       mixer_attributes:
                         attributes:
                           destination.service.host:
-                            string_value: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+                            string_value: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
                           destination.service.uid:
-                            string_value: istio://{{ .Release.Namespace }}/services/istio-telemetry
+                            string_value: istio://{{ .Release.Namespace }}/services/istio-policy
                           destination.service.name:
-                            string_value: istio-telemetry
+                            string_value: istio-policy
                           destination.service.namespace:
                             string_value: {{ .Release.Namespace }}
                           destination.uid:
@@ -205,7 +283,11 @@ data:
                             string_value: kubernetes://{{"{{"}} .PodName {{"}}"}}.{{ .Release.Namespace }}
                   transport:
                     check_cluster: mixer_check_server
-                    report_cluster: inbound_9092
+                    report_cluster: mixer_report_server
+                    attributes_for_mixer_proxy:
+                      attributes:
+                        source.uid:
+                          string_value: kubernetes://{{"{{"}} .PodName {{"}}"}}.{{ .Release.Namespace }}
                 name: mixer
               - name: envoy.router
               route_config:
@@ -213,10 +295,10 @@ data:
                 virtual_hosts:
                 - domains:
                   - '*'
-                  name: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+                  name: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
                   routes:
                   - decorator:
-                      operation: Report
+                      operation: Check
                     match:
                       prefix: /
                     route:
@@ -303,9 +385,9 @@ data:
               generate_request_id: true
               http_filters:
               - config:
-                  default_destination_service: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+                  default_destination_service: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
                   service_configs:
-                    istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}:
+                    istio-policy.{{ .Release.Namespace }}.svc.cluster.local:
                       disable_check_calls: true
     {{"{{"}}- if .DisableReportCalls {{"}}"}}
                       disable_report_calls: true
@@ -313,11 +395,11 @@ data:
                       mixer_attributes:
                         attributes:
                           destination.service.host:
-                            string_value: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+                            string_value: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
                           destination.service.uid:
-                            string_value: istio://{{ .Release.Namespace }}/services/istio-telemetry
+                            string_value: istio://{{ .Release.Namespace }}/services/istio-policy
                           destination.service.name:
-                            string_value: istio-telemetry
+                            string_value: istio-policy
                           destination.service.namespace:
                             string_value: {{ .Release.Namespace }}
                           destination.uid:
@@ -334,7 +416,11 @@ data:
                             string_value: kubernetes://{{"{{"}} .PodName {{"}}"}}.{{ .Release.Namespace }}
                   transport:
                     check_cluster: mixer_check_server
-                    report_cluster: inbound_9092
+                    report_cluster: mixer_report_server
+                    attributes_for_mixer_proxy:
+                      attributes:
+                        source.uid:
+                          string_value: kubernetes://{{"{{"}} .PodName {{"}}"}}.{{ .Release.Namespace }}
                 name: mixer
               - name: envoy.router
               route_config:
@@ -342,10 +428,10 @@ data:
                 virtual_hosts:
                 - domains:
                   - '*'
-                  name: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+                  name: istio-policy.{{ .Release.Namespace }}.svc.cluster.local
                   routes:
                   - decorator:
-                      operation: Report
+                      operation: Check
                     match:
                       prefix: /
                     route:
@@ -353,6 +439,7 @@ data:
                       timeout: 0.000s
               stat_prefix: "9091"
             name: envoy.http_connection_manager
+        name: "9091"
 
       - name: "local.15019"
         address:

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
         secret:
           secretName: policy-adapter-secret
           optional: true
+      - name: policy-envoy-config
+        configMap:
+          name: policy-envoy-config
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
@@ -95,7 +98,7 @@ spec:
 {{- end }}
 {{- if .Values.global.useMCP }}
     {{- if .Values.global.controlPlaneSecurityEnabled}}
-          - --configStoreURL=mcps://istio-galley.{{ .Values.global.configNamespace }}.svc:15019
+          - --configStoreURL=mcp://localhost:15019
     {{- else }}
           - --configStoreURL=mcp://istio-galley.{{ .Values.global.configNamespace }}.svc:9901
     {{- end }}
@@ -169,7 +172,7 @@ spec:
         - --serviceCluster
         - istio-policy
         - --templateFile
-        - /etc/istio/proxy/envoy_policy.yaml.tmpl
+        - /var/lib/envoy/envoy.yaml.tmpl
       {{- if .Values.global.controlPlaneSecurityEnabled }}
         - --controlPlaneAuthPolicy
         - MUTUAL_TLS
@@ -208,6 +211,8 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
         volumeMounts:
+        - name: policy-envoy-config
+          mountPath: /var/lib/envoy
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true

--- a/istio-policy/templates/deployment.yaml
+++ b/istio-policy/templates/deployment.yaml
@@ -213,15 +213,16 @@ spec:
         volumeMounts:
         - name: policy-envoy-config
           mountPath: /var/lib/envoy
-        - name: istio-certs
-          mountPath: /etc/certs
-          readOnly: true
         {{- if .Values.global.sds.enabled }}
         - name: sds-uds-path
           mountPath: /var/run/sds
           readOnly: true
         - name: istio-token
           mountPath: /var/run/secrets/tokens
+        {{ else }}
+        - name: istio-certs
+          mountPath: /etc/certs
+          readOnly: true
         {{- end }}
         - name: uds-socket
           mountPath: /sock

--- a/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -209,15 +209,16 @@ spec:
         volumeMounts:
         - name: telemetry-envoy-config
           mountPath: /var/lib/envoy
-        - name: istio-certs
-          mountPath: /etc/certs
-          readOnly: true
         {{- if .Values.global.sds.enabled }}
         - name: sds-uds-path
           mountPath: /var/run/sds
           readOnly: true
         - name: istio-token
           mountPath: /var/run/secrets/tokens
+        {{ else }}
+        - name: istio-certs
+          mountPath: /etc/certs
+          readOnly: true
         {{- end }}
         - name: uds-socket
           mountPath: /sock


### PR DESCRIPTION
- Fix SDS bootstrap config for Pilot, Galley, and Mixer. Prior to this, even if sds is used, aforementioned components would still use file mount certs. This will break Istio if the control plane is set to use an SDS-based CA (pods like ingress gateway will fail to connect to Pilot, etc. due to having different root certs).

- Configure the Mixer checker server to use sidecar for MCP connections to align with the rest of Istio control plane components.

This will be available only in 1.4.x.