### PR TITLE
Configure destination rules in config root namespace

### DIFF
--- a/base/templates/namespaces.yaml
+++ b/base/templates/namespaces.yaml
@@ -30,6 +30,17 @@ metadata:
 ---
 {{- end }}
 
+{{- if and (ne .Values.global.configRootNamespace .Release.Namespace) (ne .Values.global.configRootNamespace .Values.global.configNamespace) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.global.configRootNamespace }}
+  labels:
+    istio-operator-managed: Reconcile
+    istio-injection: disabled
+---
+{{- end }}
+
 {{- if ne .Values.global.telemetryNamespace .Release.Namespace }}
 apiVersion: v1
 kind: Namespace

--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -198,6 +198,14 @@ data:
 {{ toYaml .Values.global.localityLbSetting | trim | indent 6 }}
     {{- end }}
 
+    # The namespace to treat as the administrative root namespace for istio
+    # configuration.
+{{- if .Values.global.configRootNamespace }}
+    rootNamespace: {{ .Values.global.configRootNamespace }}
+{{- else }}
+    rootNamespace: {{ .Release.Namespace }}
+{{- end }}
+
     # Configures DNS certificates provisioned through Chiron linked into Pilot.
     # The DNS certificate provisioning is enabled by default now so it get tested.
     # TODO (lei-tang): we'll decide whether enable it by default or not before Istio 1.4 Release.

--- a/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -24,7 +24,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "default"
+{{- if .Values.global.configRootNamespace }}
+  namespace: {{ .Values.global.configRootNamespace }}
+{{- else }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     release: {{ .Release.Name }}
 spec:
@@ -38,7 +42,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "api-server"
+{{- if .Values.global.configRootNamespace }}
+  namespace: {{ .Values.global.configRootNamespace }}
+{{- else }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     release: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
I have configured `configRootNamespace: istio-config`, but the destination rules are put in `istio-control` where I deployed `istio-discovery`.

Also, none of them seem to be applying, and I'm pretty sure that's because the mesh's root namespace isn't configured and therefore it's falling back to `istio-system` (which doesn't exist).

https://github.com/istio/istio/blob/e921e4b7410a9e0a7c736e96a510266041d9fc7a/install/kubernetes/helm/istio/templates/configmap.yaml#L157-L163