### PR TITLE
Fixes for mixer mesh config

### DIFF
--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -45,12 +45,15 @@ data:
 
     {{- else }}
 
+    {{- if .Values.mixer.policy.enabled }}
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     mixerCheckServer: istio-policy.{{ .Values.global.policyNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}:15004
     {{- else }}
     mixerCheckServer: istio-policy.{{ .Values.global.policyNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}:9091
     {{- end }}
-    {{- if .Values.telemetry.enabled }}
+    {{- end }}
+
+    {{- if and .Values.telemetry.v1.enabled .Values.telemetry.enabled }}
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     mixerReportServer: istio-telemetry.{{ .Values.global.telemetryNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}:15004
     {{- else }}

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -134,6 +134,9 @@ mixer:
 
 telemetry:
   enabled: true
+  v1:
+    # Set true to enable Mixer based telemetry
+    enabled: true
   v2:
     # For Null VM case now. If enabled, will set disableMixerHttpReports to true and not define mixerReportServer
     # also enable metadata exchange and stats filter.

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -140,7 +140,7 @@ telemetry:
   v2:
     # For Null VM case now. If enabled, will set disableMixerHttpReports to true and not define mixerReportServer
     # also enable metadata exchange and stats filter.
-    enabled: true
+    enabled: false
     # Indicate if prometheus stats filter is enabled or not
     prometheus:
       enabled: true


### PR DESCRIPTION
* Policy disabled will remove mixerCheckServer
* decouple v2 and v1. Support telemetry v2 with no mixer at all