### PR TITLE
Correct custom-dns-names argument in citadel

### DIFF
--- a/security/citadel/templates/_helpers.tpl
+++ b/security/citadel/templates/_helpers.tpl
@@ -75,3 +75,12 @@ Create chart name and version as used by the chart label.
 {{- define "security.chart" -}}
 {{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "custom-dns-names-args" -}}
+{{ $dns_names := list }}
+{{- range $k,$v := .Values.security.dnsCerts -}}
+    {{- $arg := printf "%s:%s" $k $v -}}
+    {{- $dns_names = append $dns_names $arg -}}
+{{- end -}}
+{{- $dns_names | join "," -}}
+{{- end -}}

--- a/security/citadel/templates/deployment.yaml
+++ b/security/citadel/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           {{- if .Values.kustomize }}
             - --custom-dns-names=$(CITADEL_DNS)
           {{- else }}
-            - --custom-dns-names={{ range $k,$v := .Values.security.dnsCerts }}{{ $k }}:{{ $v }},{{ end }}
+            - --custom-dns-names={{ include "custom-dns-names-args" . }}
           {{- end }}
           {{- if .Values.security.selfSigned }}
             - --self-signed-ca=true

--- a/security/citadel/templates/service.yaml
+++ b/security/citadel/templates/service.yaml
@@ -8,7 +8,6 @@ metadata:
     app: security
     istio: citadel
     release: {{ .Release.Name }}
-
 spec:
   ports:
     - name: grpc-citadel


### PR DESCRIPTION
Without this helm will generate an argument with a trailing `,` which results in a crashing citadel:

```bash
grep 'custom-dns-names' ./istio.yml 
        - --custom-dns-names=istio-galley-service-account.istio-config:istio-galley.istio-config.svc,istio-galley-service-account.istio-control:istio-galley.istio-control.svc,istio-galley-service-account.istio-control-master:istio-galley.istio-control-master.svc,istio-galley-service-account.istio-master:istio-galley.istio-master.svc,istio-galley-service-account.istio-pilot11:istio-galley.istio-pilot11.svc,istio-pilot-service-account.istio-control:istio-pilot.istio-control,istio-pilot-service-account.istio-pilot11:istio-pilot.istio-system,istio-sidecar-injector-service-account.istio-control:istio-sidecar-injector.istio-control.svc,istio-sidecar-injector-service-account.istio-control-master:istio-sidecar-injector.istio-control-master.svc,istio-sidecar-injector-service-account.istio-master:istio-sidecar-injector.istio-master.svc,istio-sidecar-injector-service-account.istio-pilot11:istio-sidecar-injector.istio-pilot11.svc,istio-sidecar-injector-service-account.istio-remote:istio-sidecar-injector.istio-remote.svc,
```
