### PR TITLE
Add missing auto-mtls env var

### DIFF
--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -188,6 +188,10 @@ spec:
           - name: ISTIO_META_MESH_ID
             value: "{{ $.Values.global.trustDomain }}"
           {{- end }}
+          {{- if $.Values.global.mtls.auto }}
+          - name: ISTIO_AUTO_MTLS_ENABLED
+            value: "true"
+          {{- end }}
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/gateways/istio-ingress/templates/deployment.yaml
+++ b/gateways/istio-ingress/templates/deployment.yaml
@@ -232,6 +232,10 @@ spec:
           - name: ISTIO_META_MESH_ID
             value: "{{ $.Values.global.trustDomain }}"
           {{- end }}
+          {{- if $.Values.global.mtls.auto }}
+          - name: ISTIO_AUTO_MTLS_ENABLED
+            value: "true"
+          {{- end }}
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/test/install.mk
+++ b/test/install.mk
@@ -46,6 +46,7 @@ run-build-ingress:
 	  --set global.istioNamespace=istio-micro \
 	  --set global.k8sIngress.enabled=true \
       --set global.controlPlaneSecurityEnabled=false \
+	  --set global.mtls.auto=false \
       > test/knative/istio-ingress.gen.yaml
 
 run-build-citadel:

--- a/test/minimal/disable-automtls.yaml
+++ b/test/minimal/disable-automtls.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ingressgateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: istio-proxy
+          env:
+          - name: ISTIO_AUTO_MTLS_ENABLED
+            value: "false"

--- a/test/minimal/kustomization.yaml
+++ b/test/minimal/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 
 patchesStrategicMerge:
   - allocation.yaml
+  - disable-automtls.yaml
 
 #commonLabels:
 #  release: istio-minimal


### PR DESCRIPTION
This is causing failed tests when using operator, because ingress starts
without waiting for certs. See
https://github.com/istio/istio/issues/19746.

This matches istio/istio.