### PR TITLE
Not limit to the owned namespace

### DIFF
--- a/test/k8s/sidecar-local.yaml
+++ b/test/k8s/sidecar-local.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   egress:
     - hosts:
-        - "./*"
+        - "*/*"


### PR DESCRIPTION
This PR is related with issue - https://github.com/istio/istio/issues/19139 and PR - https://github.com/istio/installer/pull/567

Once enable the policy check, the productpage in bookinfo namespace have to communicate with istio-policy in istio-system namespace. so change it to all.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>