### PR TITLE
Remove duplicated policyCheckFailOpen and consolidate disablePolicyCh…

### DIFF
--- a/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-control/istio-discovery/templates/configmap.yaml
@@ -99,21 +99,9 @@ data:
     disableMixerHttpReports: false
     {{- end }}
 
-    {{- if not .Values.global.disablePolicyChecks }}
-
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: false
-
-    # policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached.
-    # Default is false which means the traffic is denied when the client is unable to connect to Mixer.
-    policyCheckFailOpen: {{ .Values.global.policyCheckFailOpen }}
-
-    {{- else }}
-
-    disablePolicyChecks: true
-
-    {{- end }}
+    disablePolicyChecks: {{ .Values.global.disablePolicyChecks }}
 
     # Automatic protocol detection uses a set of heuristics to
     # determine whether the connection is using TLS or not (on the


### PR DESCRIPTION
The `policyCheckFailOpen` is defined here already:
https://github.com/istio/installer/blob/c6a9af8306d2e7dcaeb5d273cbb44f5466be1c16/istio-control/istio-discovery/templates/configmap.yaml#L75-L80

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>