### PR TITLE
Fixes for istiod injection

### DIFF
--- a/istio-control/istio-autoinject/templates/clusterrole.yaml
+++ b/istio-control/istio-autoinject/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,4 +17,5 @@ rules:
   resources: ["mutatingwebhookconfigurations"]
   resourceNames: ["istio-sidecar-injector", "istio-sidecar-injector-{{.Release.Namespace}}"]
   verbs: ["get", "list", "watch", "patch"]
+{{- end }}
 {{- end }}

--- a/istio-control/istio-autoinject/templates/clusterrolebinding.yaml
+++ b/istio-control/istio-autoinject/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,3 +15,4 @@ subjects:
   - kind: ServiceAccount
     name: istio-sidecar-injector-service-account
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/istio-control/istio-autoinject/templates/configmap.yaml
+++ b/istio-control/istio-autoinject/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -100,3 +101,4 @@ data:
       {{- end }}
     {{- end }}
 ---
+{{- end }}

--- a/istio-control/istio-autoinject/templates/deployment.yaml
+++ b/istio-control/istio-autoinject/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -136,4 +137,5 @@ spec:
 {{- else if .Values.global.defaultTolerations }}
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}
 {{- end }}

--- a/istio-control/istio-autoinject/templates/poddisruptionbudget.yaml
+++ b/istio-control/istio-autoinject/templates/poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
       app: sidecar-injector
       release: {{ .Release.Name }}
       istio: sidecar-injector
+{{- end }}
 {{- end }}

--- a/istio-control/istio-autoinject/templates/service.yaml
+++ b/istio-control/istio-autoinject/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     targetPort: 9443
   selector:
     istio: sidecar-injector
+{{- end }}

--- a/istio-control/istio-autoinject/templates/serviceaccount.yaml
+++ b/istio-control/istio-autoinject/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -13,3 +14,4 @@ metadata:
     app: sidecarInjectorWebhook
     release: {{ .Release.Name }}
     istio: sidecar-injector
+{{- end }}

--- a/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
+++ b/istio-control/istio-autoinject/templates/sidecar-injector-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.istiod.enabled }}
 {{- if not .Values.global.omitSidecarInjectorConfigMap }}
 apiVersion: v1
 kind: ConfigMap
@@ -24,4 +25,5 @@ data:
       "{{ $key }}": "{{ $val }}"
     {{- end }}
 
+{{- end }}
 {{- end }}

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -273,7 +273,7 @@ spec:
       # Optional - image should have
       - name: inject
         configMap:
-          name: inject
+          name: istio-sidecar-injector
           optional: true
 
       {{ else }}

--- a/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: inject
+  name: istio-sidecar-injector
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
@@ -11,12 +11,20 @@ data:
     {{ .Values | toJson }}
 
   # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching
-  # and istiod webhook functionality. Policy is no longer used.
+  # and istiod webhook functionality.
   #
-  # Istiod config map should not use Values - it is a 'primary' config object, users should be able
+  # New fields should not use Values - it is a 'primary' config object, users should be able
   # to fine tune it or use it with kube-inject.
   config: |-
-    policy: enabled
+    policy: {{ .Values.global.proxy.autoInject }}
+    alwaysInjectSelector:
+      {{ toYaml .Values.sidecarInjectorWebhook.alwaysInjectSelector | trim | indent 6 }}
+    neverInjectSelector:
+      {{ toYaml .Values.sidecarInjectorWebhook.neverInjectSelector | trim | indent 6 }}
+    injectedAnnotations:
+      {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
+      "{{ $key }}": "{{ $val }}"
+      {{- end }}
 
 {{ .Files.Get "files/injection-template.yaml" | trim | indent 4 }}
 

--- a/istio-control/istio-discovery/values.yaml
+++ b/istio-control/istio-discovery/values.yaml
@@ -127,6 +127,26 @@ mixer:
   policy:
     enabled: false
 
+sidecarInjectorWebhook:
+  # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
+  # always skip the injection on pods that match that label selector, regardless of the global policy.
+  # See https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions
+  neverInjectSelector: []
+  alwaysInjectSelector: []
+
+  # injectedAnnotations are additional annotations that will be added to the pod spec after injection
+  # This is primarily to support PSP annotations. For example, if you defined a PSP with the annotations:
+  #
+  # annotations:
+  #   apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+  #   apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+  #
+  # The PSP controller would add corresponding annotations to the pod spec for each container. However, this happens before
+  # the inject adds additional containers, so we must specify them explicitly here. With the above example, we could specify:
+  # injectedAnnotations:
+  #   container.apparmor.security.beta.kubernetes.io/istio-init: runtime/default
+  #   container.apparmor.security.beta.kubernetes.io/istio-proxy: runtime/default
+  injectedAnnotations: {}
 
 telemetry:
   enabled: true

--- a/test/demo/allocation.yaml
+++ b/test/demo/allocation.yaml
@@ -95,23 +95,6 @@ spec:
               cpu: 50m
               memory: 100Mi
 ---
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: sidecar-injector-webhook
-          resources:
-            requests:
-              cpu: 50m
-              memory: 100Mi
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/install.mk
+++ b/test/install.mk
@@ -118,7 +118,6 @@ install-base: install-base-chart
 	kubectl wait deployments istio-galley istio-pilot -n ${ISTIO_CONTROL_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 	bin/iop ${ISTIO_CONTROL_NS} istio-autoinject ${BASE}/istio-control/istio-autoinject --set sidecarInjectorWebhook.enableNamespacesByDefault=${ENABLE_NAMESPACES_BY_DEFAULT} \
 		 ${IOP_OPTS} ${INSTALL_OPTS}
-	kubectl wait deployments istio-sidecar-injector -n ${ISTIO_CONTROL_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 
 
 # Some tests assumes ingress is in same namespace with pilot. If "ONE_NAMESPACE" is set to 1, then install the
@@ -132,7 +131,6 @@ install-ingress:
 wait-all-system:
 	kubectl wait deployments istio-citadel -n ${ISTIO_SYSTEM_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 	kubectl wait deployments istio-galley istio-pilot -n ${ISTIO_SYSTEM_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
-	kubectl wait deployments istio-sidecar-injector -n ${ISTIO_SYSTEM_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 	kubectl wait deployments istio-ingressgateway -n ${ISTIO_SYSTEM_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 	kubectl wait deployments istio-telemetry prometheus grafana -n ${ISTIO_SYSTEM_NS} --for=condition=available --timeout=${WAIT_TIMEOUT}
 


### PR DESCRIPTION
Right now there is no way to remove the sidecar injector deployment when
using istiod. This means you will always have a bunch of config that is
unused. Instead, when istiod is enabled, remove the injector stuff.

Alternative approach would be to add an explicit flag for this, like
istiod.disableinjector or something, but I am not sure that is needed at
this time.

Additionally, add back features from the old injection to avoid
regressions. These are critical features, not just legacy junk.

Finally, reuse the old name for the configmap so existing tooling like
istioctl can continue to function correctly.