### PR TITLE
Disable mTLS for connections to kube-dns.kube-system

### DIFF
--- a/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -47,6 +47,17 @@ spec:
     tls:
       mode: DISABLE
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: disable-mtls-to-kube-dns
+  namespace: kube-system
+spec:
+  host: "kube-dns.kube-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
 {{- else }}
 # Authentication policy to enable permissive mode for all services (that have sidecar) in the mesh.
 apiVersion: "authentication.istio.io/v1alpha1"

--- a/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -33,6 +33,17 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: disable-mtls-to-kube-dns
+  namespace: kube-system
+spec:
+  host: "kube-dns.kube-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
 {{ end }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -43,17 +54,6 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   host: "kubernetes.default.svc.{{ .Values.global.proxy.clusterDomain }}"
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: disable-mtls-to-kube-dns
-  namespace: kube-system
-spec:
-  host: "kube-dns.kube-system.svc.cluster.local"
   trafficPolicy:
     tls:
       mode: DISABLE


### PR DESCRIPTION
_I imagine there's a better place to patch this, like in envoy or something._  

See istio/istio#19968 for a write-up of the issue.  TL/DR: mTLS needs to be disabled when accessing kube-dns.kube-system so DNS resolution over TCP can work.

Fixes istio/istio#19968
