### PR TITLE
fix duplicate entry of destionarule for multicluster

### DIFF
--- a/gateways/istio-egress/templates/preconfigured.yaml
+++ b/gateways/istio-egress/templates/preconfigured.yaml
@@ -68,7 +68,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: istio-multicluster-destinationrule
+  name: istio-multicluster-egressgateway
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-egressgateway

--- a/gateways/istio-ingress/templates/preconfigured.yaml
+++ b/gateways/istio-ingress/templates/preconfigured.yaml
@@ -84,7 +84,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: istio-multicluster-destinationrule
+  name: istio-multicluster-ingressgateway
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-ingressgateway


### PR DESCRIPTION
This should helps to solve the below issue when trying to install with mutli cluster:
"Error from server (AlreadyExists): error when creating "STDIN": destinationrules.networking.istio.io "istio-multicluster-destinationrule" already exists (repeated 1 times)".

It was mentioned in https://github.com/istio/istio/issues/18785#issuecomment-551913266 and the perf benchmark pipeline