### PR TITLE
Drop kube-state-metrics from kubernetes-services-monitor ServiceMonitor

### DIFF
--- a/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -200,6 +200,9 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_annotation_istio_mtls]
       action: drop
       regex: 'true'
+    - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+      action: drop
+      regex: kube-state-metrics
     - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_path]
       action: replace
       targetLabel: __metrics_path__


### PR DESCRIPTION
Prometheus Operator already comes with kube-state-metrics job. Applying this ServiceMonitor as is will create a duplicate target with the same instance label so things like rule evaluation start failing. See Prometheus log below. So one way to solve this is to drop kube-state-metrics here and let Prometheus Operator manage it. Grafana dashboard query labels will possibly need to be updated.

```level=warn ts=2020-01-09T00:22:55.396Z caller=manager.go:526 component="rule manager" group=k8s.rules msg="Evaluating rule failed" rule="record: namespace:kube_pod_container_resource_requests_cpu_cores:sum\nexpr: sum by(namespace, label_name) (sum by(namespace, pod) (kube_pod_container_resource_requests_cpu_cores{job=\"kube-state-metrics\"}\n  * on(endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~\"^(Pending|Running)$\"}\n  == 1)) * on(namespace, pod) group_left(label_name) kube_pod_labels{job=\"kube-state-metrics\"})\n" err="found duplicate series for the match group {instance=\"10.0.182.123:8080\", job=\"prometheus-operator-kube-state-metrics\", namespace=\"monitoring\", pod=\"prometheus-operator-kube-state-metrics-859d6f7cd5-6xtjj\", service=\"prometheus-operator-kube-state-metrics\"} on the right hand-side of the operation: [{__name__=\"kube_pod_status_phase\", app_kubernetes_io_instance=\"prometheus-operator\", app_kubernetes_io_name=\"kube-state-metrics\", exported_namespace=\"application\", exported_pod=\"ops-api-green-664f64cdb9-d6cb8\", instance=\"10.0.182.123:8080\", job=\"prometheus-operator-kube-state-metrics\", namespace=\"monitoring\", phase=\"Running\", pod=\"prometheus-operator-kube-state-metrics-859d6f7cd5-6xtjj\", pod_name=\"prometheus-operator-kube-state-metrics-859d6f7cd5-6xtjj\", pod_template_hash=\"859d6f7cd5\", service=\"prometheus-operator-kube-state-metrics\"}, {__name__=\"kube_pod_status_phase\", app_kubernetes_io_instance=\"prometheus-operator\", app_kubernetes_io_name=\"kube-state-metrics\", exported_namespace=\"application\", exported_pod=\"ops-api-blue-7b964f754b-mznl2\", instance=\"10.0.182.123:8080\", job=\"prometheus-operator-kube-state-metrics\", namespace=\"monitoring\", phase=\"Running\", pod=\"prometheus-operator-kube-state-metrics-859d6f7cd5-6xtjj\", pod_name=\"prometheus-operator-kube-state-metrics-859d6f7cd5-6xtjj\", pod_template_hash=\"859d6f7cd5\", service=\"prometheus-operator-kube-state-metrics\"}];many-to-many matching not allowed: matching labels must be unique on one side"```