### PR TITLE
Configure Pilot certificate provider

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -557,8 +557,12 @@ global:
   remotePilotAddress: ""
   remoteTelemetryAddress: ""
 
-  # Configure whether signing the istiod control plane certificate at k8s CA.
-  signCertAtKubernetesCa: true
+  # Configure the Pilot certificate provider.
+  # Currently, two providers are supported: "kubernetes" and "citadel".
+  # TODO (lei-tang): the default value of this option is currently set as "kubernetes" to be consistent
+  # with the existing istiod implementation and testing. As some platforms may not have k8s signing APIs,
+  # we may change the default value of this option as "citadel".
+  pilotCertProvider: "kubernetes"
 
 # Internal setting - used when generating helm templates for kustomize.
 # clusterResources controls the inclusion of cluster-wide resources when generating the charts/installing.

--- a/istio-control/istio-discovery/files/injection-template.yaml
+++ b/istio-control/istio-discovery/files/injection-template.yaml
@@ -350,7 +350,7 @@ template: |
   {{- end }}
     {{  end -}}
     volumeMounts:
-    {{- if not .Values.global.signCertAtKubernetesCa }}
+    {{- if eq .Values.global.pilotCertProvider "citadel" }}
     - mountPath: /etc/istio/citadel-ca-cert
       name: citadel-ca-cert
     {{- end }}
@@ -392,7 +392,7 @@ template: |
           path: istio-token
           expirationSeconds: 43200
           audience: {{ .Values.global.sds.token.aud }}
-  {{- if not .Values.global.signCertAtKubernetesCa }}
+  {{- if eq .Values.global.pilotCertProvider "citadel" }}
   - name: citadel-ca-cert
     configMap:
       name: istio-ca-root-cert

--- a/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-control/istio-discovery/templates/deployment.yaml
@@ -206,8 +206,8 @@ spec:
           - --log_as_json
         {{- end }}
           env:
-          - name: SIGN_CERT_AT_KUBERNETES_CA
-            value: "{{ .Values.global.signCertAtKubernetesCa }}"
+          - name: PILOT_CERT_PROVIDER
+            value: {{ .Values.global.pilotCertProvider }}
           - name: POD_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Configure Pilot certificate provider. Currently, two providers are supported: "kubernetes" and "citadel".