### PR TITLE
Disable Galley cert mount when SDS is enabled.

### DIFF
--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -90,15 +90,16 @@ spec:
 {{- end }}
           volumeMounts:
   {{- if .Values.global.configValidation }}
-          - name: istio-certs
-            mountPath: /etc/certs
-            readOnly: true
-  {{- end }}
-  {{- if .Values.global.certificates }}
+    {{- if .Values.global.certificates }}
           - name: dnscerts
             mountPath: /etc/dnscerts
             readOnly: true
-  {{- end }}
+    {{- else }}
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+    {{- end }}
+  {{- end }} # .Values.global.configValidation
           - name: config
             mountPath: /etc/config
             readOnly: true

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -179,28 +179,47 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
           volumeMounts:
+          {{- if .Values.global.sds.enabled }}
+          - name: sds-uds-path
+            mountPath: /var/run/sds
+            readOnly: true
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+          {{- else }}
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
+          {{- end }}
           - name: envoy-config
             mountPath: /var/lib/istio/galley/envoy
-{{- end }}
+{{- end }} # if .Values.global.controlPlaneSecurityEnabled
 
       volumes:
-  {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
+  {{- if .Values.global.controlPlaneSecurityEnabled }}
+      - name: envoy-config
+        configMap:
+          name: galley-envoy-config
+      {{- if .Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds
+        name: sds-uds-path
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ .Values.global.sds.token.aud }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- else }}
       - name: istio-certs
         secret:
           secretName: istio.istio-galley-service-account
+      {{- end }}
   {{- end }}
   {{- if .Values.global.certificates }}
       - name: dnscerts
         secret:
           secretName: dns.istio-galley-service-account
-  {{- end }}
-  {{- if .Values.global.controlPlaneSecurityEnabled }}
-      - name: envoy-config
-        configMap:
-          name: galley-envoy-config
   {{- end }}
       - name: config
         configMap:


### PR DESCRIPTION
We should disable Galley's istio-cert mount when SDS is enabled. This fix is necessary since Citadel (istiod) is going to only serve SDS and no longer write to secrets. Though Galley is going to be merged into Pilot (istiod), it's still valuable to have this fixed for the use cases that Galley exists.