### PR TITLE
More fix on Galley's configValidation cert mount

### DIFF
--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -87,14 +87,15 @@ spec:
 {{- end }}
           volumeMounts:
   {{- if .Values.global.configValidation }}
-          - name: istio-certs
-            mountPath: /etc/certs
-            readOnly: true
-  {{- end }}
-  {{- if .Values.global.certificates }}
+    {{- if .Values.global.certificates }}
           - name: dnscerts
             mountPath: /etc/dnscerts
             readOnly: true
+    {{- else }}
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+    {{- end }}
   {{- end }}
           - name: config
             mountPath: /etc/config

--- a/istio-control/istio-config/templates/deployment.yaml
+++ b/istio-control/istio-config/templates/deployment.yaml
@@ -184,7 +184,7 @@ spec:
             readOnly: true
           - name: istio-token
             mountPath: /var/run/secrets/tokens
-          {{ else }}
+          {{- else }}
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
@@ -192,11 +192,7 @@ spec:
 {{- end }}
 
       volumes:
-  {{- if or .Values.global.controlPlaneSecurityEnabled .Values.global.configValidation }}
-      - name: istio-certs
-        secret:
-          secretName: istio.istio-galley-service-account
-      {{- if .Values.global.sds.enabled }}
+  {{- if and .Values.global.controlPlaneSecurityEnabled .Values.global.sds.enabled }}
       - hostPath:
           path: /var/run/sds
         name: sds-uds-path
@@ -207,12 +203,16 @@ spec:
               audience: {{ .Values.global.sds.token.aud }}
               expirationSeconds: 43200
               path: istio-token
-      {{- end }}
   {{- end }}
-  {{- if .Values.global.certificates }}
+  {{- if and .Values.global.configValidation .Values.global.certificates }}
       - name: dnscerts
         secret:
           secretName: dns.istio-galley-service-account
+  {{- end }}
+  {{- if or (and .Values.global.controlPlaneSecurityEnabled (not .Values.global.sds.enabled)) (and .Values.global.configValidation (not .Values.global.certificates)) }}
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-galley-service-account
   {{- end }}
   {{- if .Values.global.controlPlaneSecurityEnabled }}
       - name: envoy-config


### PR DESCRIPTION
This is a fix for the remaining issue in https://github.com/istio/installer/pull/650. Galley should choose only one cert mount when configValidation is turned on.