### PR TITLE
Remove duplicate sdsudspath volume for egressgateway

### DIFF
--- a/gateways/istio-egress/templates/deployment.yaml
+++ b/gateways/istio-egress/templates/deployment.yaml
@@ -253,11 +253,6 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: {{ .Values.global.sds.token.aud }}
-      {{- end }}
-      {{ if .Values.global.sds.enabled }}
-      - name: sdsudspath
-        hostPath:
-          path: /var/run/sds
       {{- else }}
       - name: istio-certs
         secret:


### PR DESCRIPTION
```
$ istioctl version
client version: 1.4.4
citadel version: 1.4.4
galley version: 1.4.4
ingressgateway version: 1.4.4
nodeagent version: 
nodeagent version: 
nodeagent version: 
pilot version: 1.4.4
policy version: 1.4.4
sidecar-injector version: 1.4.4
telemetry version: 1.4.4
data plane version: 1.4.4 (1 proxies)
```

Running the following command:
```
istioctl manifest apply -f istio.yaml
```

With the following manifest:
```
# istio.yaml
apiVersion: install.istio.io/v1alpha2
kind: IstioControlPlane
spec:
  profile: sds

  gateways:
    components:
      ingressGateway:
        enabled: true
      egressGateway:
        enabled: true
```

Results in the following output:
```
- Applying manifest for component Base...
✔ Finished applying manifest for component Base.
- Applying manifest for component Citadel...
- Applying manifest for component NodeAgent...
- Applying manifest for component EgressGateway...
- Applying manifest for component Kiali...
- Applying manifest for component Pilot...
- Applying manifest for component Prometheus...
- Applying manifest for component Policy...
- Applying manifest for component Galley...
- Applying manifest for component IngressGateway...
- Applying manifest for component Telemetry...
- Applying manifest for component Injector...
- Applying manifest for component Grafana...
✘ Finished applying manifest for component EgressGateway.
✔ Finished applying manifest for component NodeAgent.
✔ Finished applying manifest for component Kiali.
✔ Finished applying manifest for component Citadel.
✔ Finished applying manifest for component Prometheus.
✔ Finished applying manifest for component Galley.
✔ Finished applying manifest for component IngressGateway.
✔ Finished applying manifest for component Injector.
✔ Finished applying manifest for component Policy.
✔ Finished applying manifest for component Pilot.
✔ Finished applying manifest for component Grafana.
✔ Finished applying manifest for component Telemetry.

Component EgressGateway - manifest apply returned the following errors:
Error: error running kubectl: exit status 1

Error detail:

The Deployment "istio-egressgateway" is invalid: spec.template.spec.volumes[2].name: Duplicate value: "sdsudspath" (repeated 1 times)


serviceaccount/istio-egressgateway-service-account unchanged
destinationrule.networking.istio.io/istio-multicluster-egressgateway unchanged
envoyfilter.networking.istio.io/istio-multicluster-egressgateway unchanged
gateway.networking.istio.io/istio-multicluster-egressgateway unchanged
virtualservice.networking.istio.io/istio-multicluster-egressgateway unchanged
poddisruptionbudget.policy/istio-egressgateway unchanged
role.rbac.authorization.k8s.io/istio-egressgateway-sds unchanged
rolebinding.rbac.authorization.k8s.io/istio-egressgateway-sds unchanged
horizontalpodautoscaler.autoscaling/istio-egressgateway unchanged
service/istio-egressgateway unchanged




✘ Errors were logged during apply operation. Please check component installation logs above.

Failed to generate and apply manifests, error: errors were logged during apply operation
```