### PR TITLE
fix: namespace isolation for ClusterRole and ClusterRoleBinding of kiali

### DIFF
--- a/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
@@ -68,7 +68,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali-viewer
+  name: kiali-viewer-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}

--- a/istio-telemetry/kiali/templates/clusterrolebinding.yaml
+++ b/istio-telemetry/kiali/templates/clusterrolebinding.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: kiali-service-account
@@ -25,7 +25,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali-viewer
+  name: kiali-viewer-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account


### PR DESCRIPTION
add namespace isolation for ClusterRole and ClusterRoleBinding of kiali so that multiple kiali can be installed.